### PR TITLE
Add support for decision validation

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -162,7 +162,7 @@ impl<T: Proposition> Consensus<T> {
             return Ok(VoteResponse::Broadcast(vote));
         }
 
-        if self.is_split_vote(&vote_count) {
+        if vote_count.is_split_vote(&self.elders, self.n_elders) {
             info!("[{}] Detected split vote", self.id());
             let merge_vote = Vote {
                 gen: signed_vote.vote.gen,
@@ -254,19 +254,6 @@ impl<T: Proposition> Consensus<T> {
                 }
             }
         }
-    }
-
-    fn is_split_vote(&self, count: &VoteCount<T>) -> bool {
-        let most_votes = count
-            .candidate_with_most_votes()
-            .map(|(_, c)| c)
-            .unwrap_or(0);
-        let remaining_voters = self.n_elders - count.voters.len();
-
-        // suppose the remaining votes go to the proposals with the most votes.
-        let predicted_votes = most_votes + remaining_voters;
-
-        count.voters.len() > self.elders.threshold() && predicted_votes <= self.elders.threshold()
     }
 
     pub fn detect_byzantine_voters(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -182,7 +182,7 @@ impl<T: Proposition> Consensus<T> {
             return Ok(resp);
         }
 
-        if self.is_super_majority(&vote_count) {
+        if vote_count.do_we_have_supermajority(&self.elders) {
             info!("[{}] Detected super majority", self.id());
 
             if let Some(our_vote) = self.votes.get(&self.id()) {
@@ -269,15 +269,6 @@ impl<T: Proposition> Consensus<T> {
         count.voters.len() > self.elders.threshold() && predicted_votes <= self.elders.threshold()
     }
 
-    pub fn is_super_majority(&self, count: &VoteCount<T>) -> bool {
-        let most_votes = count
-            .candidate_with_most_votes()
-            .map(|(_, c)| c)
-            .unwrap_or_default();
-
-        most_votes > self.elders.threshold()
-    }
-
     pub fn detect_byzantine_voters(
         &self,
         signed_vote: &SignedVote<T>,
@@ -336,7 +327,7 @@ impl<T: Proposition> Consensus<T> {
                     .map(|(c, _)| c.proposals.clone())
                     .unwrap_or_default();
 
-                if !self.is_super_majority(&vote_count) {
+                if !vote_count.do_we_have_supermajority(&self.elders) {
                     // TODO: this should be moved to fault detection
                     Err(Error::SuperMajorityBallotIsNotSuperMajority)
                 } else if !candidate_proposals.iter().eq(proposals.keys()) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::sn_membership::Generation;
 use crate::vote::{Ballot, Proposition, SignedVote, Vote};
-use crate::{Decision, Error, Fault, NodeId, Result, VoteCount};
+use crate::{Decision, Fault, NodeId, Result, VoteCount};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Consensus<T: Proposition> {

--- a/src/decision.rs
+++ b/src/decision.rs
@@ -1,0 +1,37 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use blsttc::{PublicKeySet, Signature};
+
+use crate::{Error, Fault, Generation, NodeId, Proposition, Result, SignedVote};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decision<T: Proposition> {
+    pub votes: BTreeSet<SignedVote<T>>,
+    pub proposals: BTreeMap<T, Signature>,
+    pub faults: BTreeSet<Fault<T>>,
+}
+
+impl<T: Proposition> Decision<T> {
+    pub fn validate(&self, voters: &PublicKeySet) -> Result<()> {
+        let proposals = BTreeSet::from_iter(self.proposals.keys());
+        for vote in self.votes.iter() {
+            vote.validate_signature(voters)?;
+            let count = vote.vote_count();
+        }
+
+        Ok(())
+    }
+
+    pub fn faulty_ids(&self) -> BTreeSet<NodeId> {
+        BTreeSet::from_iter(self.faults.iter().map(Fault::voter_at_fault))
+    }
+
+    /// Returns the generation of this decision.
+    /// Assumes that Decision::validate() has already been checked.
+    pub fn generation(&self) -> Result<Generation> {
+        match self.votes.iter().next() {
+            Some(vote) => Ok(vote.vote.gen),
+            None => Err(Error::DecisionHasNoVotes),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ pub enum Error {
     InvalidGeneration(Generation),
     #[error("History contains an invalid vote")]
     InvalidVoteInHistory,
+    #[error("Invalid decision")]
+    InvalidDecision,
     #[error("Failed to encode with bincode")]
     Encoding(#[from] bincode::Error),
     #[error("Elder signature is not valid")]
@@ -49,6 +51,8 @@ pub enum Error {
     Blsttc(#[from] blsttc::error::Error),
     #[error("Client attempted a faulty proposal")]
     AttemptedFaultyProposal,
+    #[error("Fault is not a valid fault: {0:?}")]
+    FaultIsFaulty(crate::fault::FaultError),
 
     #[cfg(feature = "ed25519")]
     #[error("Ed25519 Error {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[error("You must be a member to request to leave")]
     LeaveRequestForNonMember,
     #[error("A merged vote must be from the same generation as the child vote: {child_gen} != {merge_gen}")]
-    MergedVotesMustBeFromSameGen {
+    ParentAndChildWithDiffGen {
         child_gen: Generation,
         merge_gen: Generation,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
         requested_gen: Generation,
         gen: Generation,
     },
+    #[error("Decision doesn't have any votes")]
+    DecisionHasNoVotes,
     #[error("The voter is not an elder")]
     NotElder,
     #[error("Voter changed their vote")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod consensus;
+pub mod decision;
 pub mod fault;
 pub mod sn_handover;
 pub mod sn_membership;
@@ -14,7 +15,8 @@ pub mod ed25519;
 use blsttc::{PublicKeySet, SignatureShare};
 use serde::Serialize;
 
-pub use crate::consensus::{Consensus, Decision, VoteResponse};
+pub use crate::consensus::{Consensus, VoteResponse};
+pub use crate::decision::Decision;
 pub use crate::fault::{Fault, FaultError};
 pub use crate::sn_handover::{Handover, UniqueSectionId};
 pub use crate::sn_membership::{Generation, Membership, Reconfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod fault;
 pub mod sn_handover;
 pub mod sn_membership;
 pub mod vote;
+pub mod vote_count;
 
 #[cfg(feature = "bad_crypto")]
 pub mod bad_crypto;
@@ -21,6 +22,7 @@ pub use crate::fault::{Fault, FaultError};
 pub use crate::sn_handover::{Handover, UniqueSectionId};
 pub use crate::sn_membership::{Generation, Membership, Reconfig};
 pub use crate::vote::{Ballot, Proposition, SignedVote, Vote};
+pub use crate::vote_count::{Candidate, VoteCount};
 
 // #[cfg(feature = "bad_crypto")]
 // pub use crate::bad_crypto::{PublicKey, SecretKey, Signature};

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -37,8 +37,12 @@ impl<T: Proposition> Handover<T> {
         };
         let signed_vote = self.sign_vote(vote)?;
         self.validate_proposals(&signed_vote)?;
-        self.consensus
-            .detect_byzantine_voters(&signed_vote)
+        signed_vote
+            .detect_byzantine_faults(
+                &self.consensus.elders,
+                &self.consensus.votes,
+                &self.consensus.processed_votes_cache,
+            )
             .map_err(|_| Error::AttemptedFaultyProposal)?;
         self.cast_vote(signed_vote)
     }

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -148,8 +148,12 @@ impl<T: Proposition> Membership<T> {
         };
         let signed_vote = self.sign_vote(vote)?;
         self.validate_proposals(&signed_vote)?;
-        self.consensus
-            .detect_byzantine_voters(&signed_vote)
+        signed_vote
+            .detect_byzantine_faults(
+                &self.consensus.elders,
+                &self.consensus.votes,
+                &self.consensus.processed_votes_cache,
+            )
             .map_err(|_| Error::AttemptedFaultyProposal)?;
         self.cast_vote(signed_vote)
     }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
 
 use blsttc::{PublicKeySet, SignatureShare};
@@ -6,7 +5,7 @@ use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use crate::sn_membership::Generation;
-use crate::{Fault, NodeId, Result};
+use crate::{Candidate, Fault, NodeId, Result, VoteCount};
 
 pub trait Proposition: Ord + Clone + Debug + Serialize {}
 impl<T: Ord + Clone + Debug + Serialize> Proposition for T {}
@@ -65,126 +64,6 @@ pub fn proposals<T: Proposition>(
             .filter_map(|v| v.vote.ballot.as_proposal())
             .cloned(),
     )
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Candidate<T> {
-    pub proposals: BTreeSet<T>,
-    pub faulty: BTreeSet<NodeId>,
-}
-
-impl<T> Default for Candidate<T> {
-    fn default() -> Self {
-        Self {
-            proposals: Default::default(),
-            faulty: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SuperMajorityCount<T> {
-    pub count: usize,
-    pub proposals: BTreeMap<T, BTreeMap<u64, SignatureShare>>,
-}
-
-impl<T> Default for SuperMajorityCount<T> {
-    fn default() -> Self {
-        Self {
-            count: 0,
-            proposals: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VoteCount<T> {
-    pub candidates: BTreeMap<Candidate<T>, usize>,
-    pub super_majorities: BTreeMap<Candidate<T>, SuperMajorityCount<T>>,
-    pub voters: BTreeSet<NodeId>,
-}
-
-impl<T> Default for VoteCount<T> {
-    fn default() -> Self {
-        Self {
-            candidates: Default::default(),
-            super_majorities: Default::default(),
-            voters: Default::default(),
-        }
-    }
-}
-
-impl<T: Proposition> VoteCount<T> {
-    pub fn count<V: Borrow<SignedVote<T>>>(
-        votes: impl IntoIterator<Item = V>,
-        faulty: &BTreeSet<NodeId>,
-    ) -> Self {
-        let mut count: VoteCount<T> = VoteCount::default();
-
-        let mut votes_by_honest_voter: BTreeMap<NodeId, SignedVote<T>> = Default::default();
-
-        for vote in votes.into_iter() {
-            for unpacked_vote in vote.borrow().unpack_votes() {
-                if faulty.contains(&unpacked_vote.voter) {
-                    continue;
-                }
-                let existing_vote = votes_by_honest_voter
-                    .entry(unpacked_vote.voter)
-                    .or_insert_with(|| unpacked_vote.clone());
-                if unpacked_vote.supersedes(existing_vote) {
-                    *existing_vote = unpacked_vote.clone();
-                }
-            }
-        }
-
-        // We always include voters in the voter set (even if they are faulty)
-        // so that we have an accurate reading of who has contributed votes.
-        // This is done to to aid in split-vote detection
-        count.voters.extend(votes_by_honest_voter.keys().copied());
-        count.voters.extend(faulty.iter().copied());
-
-        for vote in votes_by_honest_voter.into_values() {
-            let candidate = vote.candidate();
-
-            if let Ballot::SuperMajority { proposals, .. } = &vote.vote.ballot {
-                let sm_count = count.super_majorities.entry(candidate.clone()).or_default();
-
-                sm_count.count += 1;
-
-                for (t, (id, sig)) in proposals {
-                    sm_count
-                        .proposals
-                        .entry(t.clone())
-                        .or_default()
-                        .insert(*id as u64, sig.clone());
-                }
-            }
-
-            let c = count.candidates.entry(candidate).or_default();
-            *c += 1;
-        }
-
-        count
-    }
-
-    pub fn candidate_with_most_votes(&self) -> Option<(&Candidate<T>, usize)> {
-        self.candidates
-            .iter()
-            .map(|(candidates, c)| (candidates, *c))
-            .chain(
-                self.super_majority_with_most_votes()
-                    .map(|(candidates, sm_count)| (candidates, sm_count.count)),
-            )
-            .max_by_key(|(_, c)| *c)
-    }
-
-    pub fn super_majority_with_most_votes(
-        &self,
-    ) -> Option<(&Candidate<T>, &SuperMajorityCount<T>)> {
-        self.super_majorities
-            .iter()
-            .max_by_key(|(_, sm_count)| sm_count.count)
-    }
 }
 
 impl<T: Proposition> Ballot<T> {

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -140,7 +140,7 @@ impl<T: Proposition> Vote<T> {
                     .map(|(c, _)| c.proposals.clone())
                     .unwrap_or_default();
 
-                if !vote_count.do_we_have_supermajority(&voters) {
+                if !vote_count.do_we_have_supermajority(voters) {
                     // TODO: this should be moved to fault detection
                     Err(Error::SuperMajorityBallotIsNotSuperMajority)
                 } else if !candidate_proposals.iter().eq(proposals.keys()) {
@@ -148,7 +148,7 @@ impl<T: Proposition> Vote<T> {
                     Err(Error::SuperMajorityProposalsDoesNotMatchVoteProposals)
                 } else if proposals
                     .iter()
-                    .try_for_each(|(p, (id, sig))| crate::verify_sig_share(&p, sig, *id, &voters))
+                    .try_for_each(|(p, (id, sig))| crate::verify_sig_share(&p, sig, *id, voters))
                     .is_err()
                 {
                     Err(Error::InvalidElderSignature)
@@ -224,8 +224,8 @@ impl<T: Proposition> SignedVote<T> {
         voters: &PublicKeySet,
         valid_votes_cache: &BTreeSet<SignatureShare>,
     ) -> Result<()> {
-        self.validate_signature(&voters)?;
-        self.vote.validate(&voters, &valid_votes_cache)?;
+        self.validate_signature(voters)?;
+        self.vote.validate(voters, valid_votes_cache)?;
 
         Ok(())
     }

--- a/src/vote_count.rs
+++ b/src/vote_count.rs
@@ -126,6 +126,22 @@ impl<T: Proposition> VoteCount<T> {
             .max_by_key(|(_, sm_count)| sm_count.count)
     }
 
+    pub fn is_split_vote(&self, voters: &PublicKeySet, n_voters: usize) -> bool {
+        let most_votes = self
+            .candidate_with_most_votes()
+            .map(|(_, c)| c)
+            .unwrap_or(0);
+
+        let remaining_voters = n_voters - self.voters.len();
+
+        // suppose the remaining votes go to the proposals with the most votes.
+        let predicted_votes = most_votes + remaining_voters;
+
+        // We're in a split vote if even in the best case scenario where all
+        // remaining votes are not enough to take us above the threshold.
+        predicted_votes <= voters.threshold()
+    }
+
     pub fn do_we_have_supermajority(&self, voters: &PublicKeySet) -> bool {
         let most_votes = self
             .candidate_with_most_votes()

--- a/src/vote_count.rs
+++ b/src/vote_count.rs
@@ -1,0 +1,152 @@
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet},
+};
+
+use blsttc::{PublicKeySet, Signature, SignatureShare};
+
+use crate::{Ballot, NodeId, Proposition, Result, SignedVote};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Candidate<T> {
+    pub proposals: BTreeSet<T>,
+    pub faulty: BTreeSet<NodeId>,
+}
+
+impl<T> Default for Candidate<T> {
+    fn default() -> Self {
+        Self {
+            proposals: Default::default(),
+            faulty: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuperMajorityCount<T> {
+    pub count: usize,
+    pub proposals: BTreeMap<T, BTreeMap<u64, SignatureShare>>,
+}
+
+impl<T> Default for SuperMajorityCount<T> {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            proposals: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoteCount<T> {
+    pub candidates: BTreeMap<Candidate<T>, usize>,
+    pub super_majorities: BTreeMap<Candidate<T>, SuperMajorityCount<T>>,
+    pub voters: BTreeSet<NodeId>,
+}
+
+impl<T> Default for VoteCount<T> {
+    fn default() -> Self {
+        Self {
+            candidates: Default::default(),
+            super_majorities: Default::default(),
+            voters: Default::default(),
+        }
+    }
+}
+
+impl<T: Proposition> VoteCount<T> {
+    pub fn count<V: Borrow<SignedVote<T>>>(
+        votes: impl IntoIterator<Item = V>,
+        faulty: &BTreeSet<NodeId>,
+    ) -> Self {
+        let mut count: VoteCount<T> = VoteCount::default();
+
+        let mut votes_by_honest_voter: BTreeMap<NodeId, SignedVote<T>> = Default::default();
+
+        for vote in votes.into_iter() {
+            for unpacked_vote in vote.borrow().unpack_votes() {
+                if faulty.contains(&unpacked_vote.voter) {
+                    continue;
+                }
+                let existing_vote = votes_by_honest_voter
+                    .entry(unpacked_vote.voter)
+                    .or_insert_with(|| unpacked_vote.clone());
+                if unpacked_vote.supersedes(existing_vote) {
+                    *existing_vote = unpacked_vote.clone();
+                }
+            }
+        }
+
+        // We always include voters in the voter set (even if they are faulty)
+        // so that we have an accurate reading of who has contributed votes.
+        // This is done to to aid in split-vote detection
+        count.voters.extend(votes_by_honest_voter.keys().copied());
+        count.voters.extend(faulty.iter().copied());
+
+        for vote in votes_by_honest_voter.into_values() {
+            let candidate = vote.candidate();
+
+            if let Ballot::SuperMajority { proposals, .. } = &vote.vote.ballot {
+                let sm_count = count.super_majorities.entry(candidate.clone()).or_default();
+
+                sm_count.count += 1;
+
+                for (t, (id, sig)) in proposals {
+                    sm_count
+                        .proposals
+                        .entry(t.clone())
+                        .or_default()
+                        .insert(*id as u64, sig.clone());
+                }
+            }
+
+            let c = count.candidates.entry(candidate).or_default();
+            *c += 1;
+        }
+
+        count
+    }
+
+    pub fn candidate_with_most_votes(&self) -> Option<(&Candidate<T>, usize)> {
+        self.candidates
+            .iter()
+            .map(|(candidates, c)| (candidates, *c))
+            .chain(
+                self.super_majority_with_most_votes()
+                    .map(|(candidates, sm_count)| (candidates, sm_count.count)),
+            )
+            .max_by_key(|(_, c)| *c)
+    }
+
+    pub fn super_majority_with_most_votes(
+        &self,
+    ) -> Option<(&Candidate<T>, &SuperMajorityCount<T>)> {
+        self.super_majorities
+            .iter()
+            .max_by_key(|(_, sm_count)| sm_count.count)
+    }
+
+    pub fn do_we_have_supermajority(&self, voters: &PublicKeySet) -> bool {
+        let most_votes = self
+            .candidate_with_most_votes()
+            .map(|(_, c)| c)
+            .unwrap_or_default();
+
+        most_votes > voters.threshold()
+    }
+
+    pub fn get_decision(&self, voters: &PublicKeySet) -> Result<Option<BTreeMap<T, Signature>>> {
+        if let Some((_candidate, sm_count)) = self.super_majority_with_most_votes() {
+            if sm_count.count > voters.threshold() {
+                let proposals = sm_count
+                    .proposals
+                    .iter()
+                    .map(|(prop, sigs)| Ok((prop.clone(), voters.combine_signatures(sigs)?)))
+                    .collect::<Result<_>>()?;
+                return Ok(Some(proposals));
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/src/vote_count.rs
+++ b/src/vote_count.rs
@@ -139,7 +139,7 @@ impl<T: Proposition> VoteCount<T> {
 
         // We're in a split vote if even in the best case scenario where all
         // remaining votes are not enough to take us above the threshold.
-        predicted_votes <= voters.threshold()
+        self.voters.len() > voters.threshold() && predicted_votes <= voters.threshold()
     }
 
     pub fn do_we_have_supermajority(&self, voters: &PublicKeySet) -> bool {

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -196,6 +196,7 @@ impl Net {
                         assert_eq!(net_d.proposals, proc_d.proposals);
                     }
                     (None, Some(proc_d)) => {
+                        assert!(proc_d.validate(&proc.consensus.elders).is_ok());
                         self.decisions.insert(packet_gen, proc_d);
                     }
                     (None | Some(_), None) => (),

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -148,7 +148,8 @@ fn test_membership_split_vote() -> Result<()> {
 
         net.generate_msc(&format!("split_vote_{}.msc", nprocs))?;
 
-        let expected_members = BTreeSet::from_iter(0..=(2 * nprocs) / 3);
+        let expected_members = net.procs[0].members(1)?;
+        assert_ne!(expected_members.len(), 0);
         for i in 0..nprocs {
             info!("proc {i} / {nprocs}");
             let proc = &net.procs[i as usize];


### PR DESCRIPTION
We'd like to broadcast consensus decisions to other nodes in a section. In order to do this, nodes need to be able to validate decisions.

This PR moves all the validation functions onto the `Vote` structs instead of having them on the `Consensus` struct. This allows anyone to validate votes if they have access to them.

With those changes in place, we also add a `Decision::validate(..)` API to support validation of any decision reached by consensus.