### PR TITLE
chore: upgrade blsttc to 6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.13"
   features = [ "derive" ]
 
   [dependencies.blsttc]
-  version = "5.2.0"
+  version = "6.0.0"
 
   [dependencies.ed25519]
   version = "1.0.0"


### PR DESCRIPTION
The new version contains utilities for converting keys to hex and is needed by crates in the safe_network workspace.