### PR TITLE
vcbc: removing parties from context

### DIFF
--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -8,7 +8,7 @@ mod pre_process;
 
 use blsttc::{PublicKeySet, PublicKeyShare};
 
-use self::error::{Result};
+use self::error::Result;
 use self::message::Message;
 use self::pre_process::ProposeState;
 use self::state::State;

--- a/src/mvba/abba/pre_process.rs
+++ b/src/mvba/abba/pre_process.rs
@@ -1,7 +1,6 @@
 use super::context;
 use super::error::Result;
 
-
 use super::State;
 
 pub(super) struct ProposeState {

--- a/src/mvba/abba/state.rs
+++ b/src/mvba/abba/state.rs
@@ -1,9 +1,9 @@
 use blsttc::PublicKeyShare;
 
-use super::error::{Result};
+use super::context;
+use super::error::Result;
 use super::message::Message;
 use super::message_set::MessageSet;
-use super::{context};
 
 use std::collections::hash_map::Entry;
 

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -35,15 +35,20 @@ impl Consensus {
         let broadcaster = Broadcaster::new(id, &secret_key, self_id);
         let broadcaster_rc = Rc::new(RefCell::new(broadcaster));
 
-        let abba = Abba::new(pub_key_set.clone(), number, threshold, broadcaster_rc.clone());
+        let abba = Abba::new(
+            pub_key_set.clone(),
+            number,
+            threshold,
+            broadcaster_rc.clone(),
+        );
         let mut vcbc_map = HashMap::new();
 
         for id in &parties {
             let _pub_key = pub_key_set.public_key_share(id);
             let vcbc = Vcbc::new(
-                parties.clone(),
-                *id,
+                parties.len(),
                 threshold,
+                *id,
                 broadcaster_rc.clone(),
                 proposal_checker,
             );

--- a/src/mvba/vcbc/context.rs
+++ b/src/mvba/vcbc/context.rs
@@ -4,7 +4,7 @@ use crate::mvba::{broadcaster::Broadcaster, proposal::Proposal, NodeId, Proposal
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
 pub(super) struct Context {
-    pub parties: Vec<NodeId>,
+    pub number: usize,
     pub threshold: usize,
     pub proposer_id: NodeId,
     pub proposal: Option<Proposal>,
@@ -16,14 +16,14 @@ pub(super) struct Context {
 
 impl Context {
     pub fn new(
-        parties: Vec<NodeId>,
+        number: usize,
         threshold: usize,
         proposer_id: NodeId,
         broadcaster: Rc<RefCell<Broadcaster>>,
         proposal_checker: ProposalChecker,
     ) -> Self {
         Self {
-            parties,
+            number,
             threshold,
             proposer_id,
             proposal: None,
@@ -38,7 +38,7 @@ impl Context {
     // There are $n$ parties, $t$ of which may be corrupted.
     // Protocol is reliable for $n > 3t$.
     pub fn super_majority_num(&self) -> usize {
-        self.parties.len() - self.threshold
+        self.number - self.threshold
     }
 
     pub fn broadcast(&self, msg: &self::Message) {

--- a/src/mvba/vcbc/error.rs
+++ b/src/mvba/vcbc/error.rs
@@ -3,8 +3,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("invalid sender: {0:?}")]
-    InvalidSender(NodeId),
     #[error("invalid proposer. expected {0:?}, get {1:?}")]
     InvalidProposer(NodeId, NodeId),
     #[error("invalid proposal: {0:?}")]

--- a/src/mvba/vcbc/message.rs
+++ b/src/mvba/vcbc/message.rs
@@ -1,6 +1,5 @@
 use crate::mvba::proposal::Proposal;
 
-
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) enum Message {
     Propose(Proposal),

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -29,22 +29,20 @@ pub(crate) struct Vcbc {
 
 impl Vcbc {
     pub fn new(
-        parties: Vec<NodeId>,
-        proposer_id: NodeId,
+        number: usize,
         threshold: usize,
+        proposer_id: NodeId,
         broadcaster: Rc<RefCell<Broadcaster>>,
         proposal_checker: ProposalChecker,
     ) -> Self {
-        let ctx = context::Context::new(
-            parties,
-            threshold,
-            proposer_id,
-            broadcaster,
-            proposal_checker,
-        );
-
         Self {
-            ctx,
+            ctx : context::Context::new(
+                number,
+                threshold,
+                proposer_id,
+                broadcaster,
+                proposal_checker,
+            ),
             state: Box::new(ProposeState),
         }
     }

--- a/src/mvba/vcbc/state.rs
+++ b/src/mvba/vcbc/state.rs
@@ -1,9 +1,8 @@
+use super::context;
 use super::error::{Error, Result};
 use super::message::Message;
-use super::{context};
 use crate::mvba::proposal::Proposal;
 use crate::mvba::NodeId;
-
 
 pub(super) trait State {
     // enters to the new state
@@ -51,9 +50,6 @@ pub(super) trait State {
     ) -> Result<()> {
         log::debug!("{} processing message: {:?}", self.name(), msg);
 
-        if !ctx.parties.contains(sender) {
-            return Err(Error::InvalidSender(*sender));
-        }
         match msg {
             Message::Propose(proposal) => {
                 self.set_proposal(proposal, ctx)?;
@@ -62,7 +58,6 @@ pub(super) trait State {
                 self.set_proposal(proposal, ctx)?;
                 self.add_echo(sender, ctx);
             }
-            _ => {}
         }
 
         Ok(())

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -34,13 +34,7 @@ impl TestData {
             &proposer_key,
             Some(Self::PARTY_X),
         )));
-        let vcbc = Vcbc::new(
-            vec![Self::PARTY_X, Self::PARTY_Y, Self::PARTY_B, Self::PARTY_S],
-            proposer_id,
-            1,
-            broadcaster.clone(),
-            valid_proposal,
-        );
+        let vcbc = Vcbc::new(4, 1, proposer_id, broadcaster.clone(), valid_proposal);
 
         // Creating a random proposal
         let mut rng = rand::thread_rng();
@@ -176,26 +170,5 @@ fn test_duplicated_proposal() {
     assert_eq!(
         t.vcbc.process_message(&TestData::PARTY_B, &data).err(),
         Some(Error::DuplicatedProposal(duplicated_proposal)),
-    );
-}
-
-#[test]
-fn test_byzantine_messages() {
-    let mut t = TestData::new(TestData::PARTY_B);
-
-    let mut byz_proposal = t.proposal.clone();
-    byz_proposal.proposer_id = 66; // unknown proposer
-    let data = bincode::serialize(&Message::Propose(byz_proposal.clone())).unwrap();
-    assert_eq!(
-        t.vcbc.process_message(&TestData::PARTY_B, &data).err(),
-        Some(Error::InvalidProposer(
-            TestData::PARTY_B,
-            byz_proposal.proposer_id
-        ))
-    );
-
-    assert_eq!(
-        t.vcbc.process_message(&66, &t.propose_msg()).err(),
-        Some(Error::InvalidSender(66))
     );
 }


### PR DESCRIPTION
The context in VCBC now is agnostic about parties (which is good). Instead of that, it holds the number of parties.
Still `cargo clippy` returns some issues, please ignore it. I will fix it ASAP.