### PR TITLE
refactor(abba): replace id with tag in ABBA

### DIFF
--- a/src/mvba/abba/message.rs
+++ b/src/mvba/abba/message.rs
@@ -1,6 +1,8 @@
 use blsttc::{Signature, SignatureShare};
 use serde::{Deserialize, Serialize};
 
+use crate::mvba::vcbc::message::Tag;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PreVoteValue {
     One,
@@ -59,7 +61,7 @@ pub enum Action {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    pub id: String,
+    pub tag: Tag,
     pub action: Action,
 }
 

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -53,9 +53,8 @@ impl Consensus {
             vcbc_map.insert(*id, vcbc).unwrap();
 
             let abba = Abba::new(
-                format!("{}", id),
-                self_id,
                 tag,
+                self_id,
                 pub_key_set.clone(),
                 sec_key_share.clone(),
                 broadcaster_rc.clone(),


### PR DESCRIPTION
`Tag::id` does the same job as the `id` in `Abba`. Since we already have an tag in ABBA, we don't need the id.

I also expanded some of the variable names to make it easier to follow the logic.