### PR TITLE
fix(vcbc): remove unwraps in reading delivered values

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,44 +42,6 @@ jobs:
       - name: Clippy checks # --feature blsttc
         run: cargo clippy --all-targets # --no-default-features --features "blsttc"
 
-  coverage:
-    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
-    name: Code coverage check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: rust-tarpaulin code coverage check
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '-v --release --out Lcov'
-      - name: Push code coverage results to coveralls.io
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./lcov.info
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-
   build:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Build

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -104,7 +104,7 @@ impl Consensus {
                     Some(vcbc) => {
                         let msg = bincode::deserialize(&bundle.payload)?;
                         vcbc.receive_message(bundle.initiator, msg)?;
-                        if vcbc.is_delivered() {
+                        if let Some((proposal, sig)) = vcbc.read_delivered() {
                             // Check if we have agreed on this proposal before.
                             //    There might be a situation that we receive the agreement
                             //    before receiving the actual proposal.
@@ -117,7 +117,6 @@ impl Consensus {
                                 }
                             }
 
-                            let (proposal, sig) = vcbc.delivered_message();
                             self.mvba.set_proposal(target, proposal, sig)?;
                         }
                     }
@@ -136,7 +135,7 @@ impl Consensus {
                         if let Some(decided_value) = abba.decided_value() {
                             if decided_value {
                                 let vcbc = self.vcbc_map.get_mut(&target).unwrap();
-                                if vcbc.is_delivered() {
+                                if vcbc.read_delivered().is_some() {
                                     // We re done! We have both proposal and agreement
                                     log::info!("halted. proposer: {target}");
                                     self.decided_party = Some(target);

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -281,23 +281,9 @@ impl Vcbc {
         Ok(())
     }
 
-    pub fn is_delivered(&self) -> bool {
-        self.u_bar.is_some()
-    }
-
-    pub fn delivered_message(&self) -> (Proposal, Signature) {
-        debug_assert!(self.u_bar.is_some(), "message should be delivered");
-
-        (
-            self.m_bar.as_ref().unwrap().clone(),
-            self.u_bar.as_ref().unwrap().clone(),
-        )
-    }
-
-    #[cfg(test)]
-    fn read_delivered(&self) -> Option<(Vec<u8>, Signature)> {
-        if let (Some(m), Some(u)) = (&self.m_bar, &self.u_bar) {
-            Some((m.clone(), u.clone()))
+    pub fn read_delivered(&self) -> Option<(Proposal, Signature)> {
+        if let (Some(proposal), Some(sig)) = (self.m_bar.clone(), self.u_bar.clone()) {
+            Some((proposal, sig))
         } else {
             None
         }

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -385,7 +385,7 @@ fn test_normal_case_operation() {
         .receive_message(TestNet::PARTY_Y, ready_msg_y)
         .unwrap();
 
-    assert!(t.vcbc.is_delivered());
+    assert!(t.vcbc.read_delivered().is_some());
 }
 
 #[test]
@@ -400,7 +400,7 @@ fn test_final_message_first() {
     t.vcbc.receive_message(TestNet::PARTY_S, final_msg).unwrap();
     t.vcbc.receive_message(TestNet::PARTY_S, send_msg).unwrap();
 
-    assert!(t.vcbc.is_delivered());
+    assert!(t.vcbc.read_delivered().is_some());
 }
 
 #[test]
@@ -502,5 +502,5 @@ fn test_c_answer() {
         .receive_message(TestNet::PARTY_S, answer_msg)
         .unwrap();
 
-    assert!(t.vcbc.is_delivered());
+    assert!(t.vcbc.read_delivered().is_some());
 }


### PR DESCRIPTION
This removes a few unwraps from the VCBC module.

part of #91 