### PR TITLE
Expose sequence number in consensus API

### DIFF
--- a/src/mvba/abba/message.rs
+++ b/src/mvba/abba/message.rs
@@ -1,7 +1,7 @@
 use blsttc::{Signature, SignatureShare};
 use serde::{Deserialize, Serialize};
 
-use crate::mvba::{hash::Hash32, vcbc::message::Tag};
+use crate::mvba::{hash::Hash32, tag::Tag};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Value {

--- a/src/mvba/abba/message.rs
+++ b/src/mvba/abba/message.rs
@@ -1,7 +1,7 @@
 use blsttc::{Signature, SignatureShare};
 use serde::{Deserialize, Serialize};
 
-use crate::mvba::{hash::Hash32, NodeId};
+use crate::mvba::{hash::Hash32, vcbc::message::Tag};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Value {
@@ -79,8 +79,7 @@ pub enum Action {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    pub id: String,       // this is same as $id$ in spec
-    pub proposer: NodeId, // this is same as $j$ or $a$ in spec
+    pub tag: Tag, // this is same as $id.j.s$ in spec
     pub action: Action,
 }
 

--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -15,6 +15,7 @@ use self::message::{
     PreVoteJustification, Value,
 };
 use super::hash::Hash32;
+use super::vcbc::message::Tag;
 use super::NodeId;
 use crate::mvba::abba::message::MainVoteJustification;
 use crate::mvba::broadcaster::Broadcaster;
@@ -452,8 +453,8 @@ impl Abba {
                         }
                     }
                     PreVoteJustification::WithValidity(digest, sig) => {
-                        let sign_bytes =
-                            crate::mvba::vcbc::c_ready_bytes_to_sign(&self.id, &self.j, digest)?;
+                        let tag = Tag::new(&self.id, self.j, 0); // TODO: this should be self.tag
+                        let sign_bytes = crate::mvba::vcbc::c_ready_bytes_to_sign(&tag, digest)?;
 
                         if !self.pub_key_set.public_key().verify(sig, sign_bytes) {
                             return Err(Error::InvalidMessage(
@@ -548,9 +549,9 @@ impl Abba {
 
                         match just_1.as_ref() {
                             PreVoteJustification::WithValidity(digest, sig) => {
-                                let sign_bytes = crate::mvba::vcbc::c_ready_bytes_to_sign(
-                                    &self.id, &self.j, digest,
-                                )?;
+                                let tag = Tag::new(&self.id, self.j, 0); // TODO: this should be self.tag
+                                let sign_bytes =
+                                    crate::mvba::vcbc::c_ready_bytes_to_sign(&tag, digest)?;
 
                                 if !self.pub_key_set.public_key().verify(sig, sign_bytes) {
                                     return Err(Error::InvalidMessage(

--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -24,10 +24,9 @@ pub(crate) const MODULE_NAME: &str = "abba";
 
 /// The ABBA holds the information for Asynchronous Binary Byzantine Agreement protocol.
 pub(crate) struct Abba {
-    id: String, // this is same as $ID$ in spec
-    i: NodeId,  // this is same as $i$ in spec
-    j: NodeId,  // this is same as $j$ in spec
-    r: usize,   // this is same as $r$ in spec
+    tag: Tag,  // this is same as ID.j.s in the spec
+    i: NodeId, // this is same as $i$ in spec
+    r: usize,  // this is same as $r$ in spec
     voted: bool,
     weak_validity: Option<(Hash32, Signature)>,
     decided_value: Option<DecisionAction>,
@@ -40,17 +39,15 @@ pub(crate) struct Abba {
 
 impl Abba {
     pub fn new(
-        id: String,
+        tag: Tag,
         self_id: NodeId,
-        proposer: NodeId,
         pub_key_set: PublicKeySet,
         sec_key_share: SecretKeyShare,
         broadcaster: Rc<RefCell<Broadcaster>>,
     ) -> Self {
         Self {
-            id,
+            tag,
             i: self_id,
-            j: proposer,
             r: 1,
             voted: false,
             weak_validity: None,
@@ -170,10 +167,9 @@ impl Abba {
                         // If these are all main-votes for b ∈ {0, 1}, then decide the value b for ID
                         if zero_votes.clone().count() >= self.threshold() {
                             log::info!(
-                                "party {} decided for zero. id={}, r={}, j={}",
+                                "party {} decided for zero. tag={}, r={}",
                                 self.i,
-                                self.id,
-                                self.j,
+                                self.tag,
                                 self.r
                             );
                             let sig_share: HashMap<&NodeId, &SignatureShare> =
@@ -191,10 +187,9 @@ impl Abba {
 
                         if one_votes.clone().count() >= self.threshold() {
                             log::info!(
-                                "party {} decided for one. id={}, r={}, j={}",
+                                "party {} decided for one. tag={}, r={}",
                                 self.i,
-                                self.id,
-                                self.j,
+                                self.tag,
                                 self.r
                             );
                             let sig_share: HashMap<&NodeId, &SignatureShare> =
@@ -411,17 +406,17 @@ impl Abba {
     }
 
     fn check_message(&self, initiator: &NodeId, msg: &Message) -> Result<()> {
-        if msg.id != self.id {
+        if msg.id != self.tag.domain {
             return Err(Error::InvalidMessage(format!(
-                "invalid ID. expected: {}, got {}",
-                self.id, msg.id
+                "invalid domain. expected: {}, got {}",
+                self.tag.domain, msg.id
             )));
         }
 
-        if msg.proposer != self.j {
+        if msg.proposer != self.tag.proposer {
             return Err(Error::InvalidMessage(format!(
                 "invalid proposer. expected: {}, got {}",
-                self.j, msg.proposer
+                self.tag.proposer, msg.proposer
             )));
         }
 
@@ -453,8 +448,8 @@ impl Abba {
                         }
                     }
                     PreVoteJustification::WithValidity(digest, sig) => {
-                        let tag = Tag::new(&self.id, self.j, 0); // TODO: this should be self.tag
-                        let sign_bytes = crate::mvba::vcbc::c_ready_bytes_to_sign(&tag, digest)?;
+                        let sign_bytes =
+                            crate::mvba::vcbc::c_ready_bytes_to_sign(&self.tag, digest)?;
 
                         if !self.pub_key_set.public_key().verify(sig, sign_bytes) {
                             return Err(Error::InvalidMessage(
@@ -549,9 +544,8 @@ impl Abba {
 
                         match just_1.as_ref() {
                             PreVoteJustification::WithValidity(digest, sig) => {
-                                let tag = Tag::new(&self.id, self.j, 0); // TODO: this should be self.tag
                                 let sign_bytes =
-                                    crate::mvba::vcbc::c_ready_bytes_to_sign(&tag, digest)?;
+                                    crate::mvba::vcbc::c_ready_bytes_to_sign(&self.tag, digest)?;
 
                                 if !self.pub_key_set.public_key().verify(sig, sign_bytes) {
                                     return Err(Error::InvalidMessage(
@@ -591,14 +585,14 @@ impl Abba {
         log::debug!("party {} broadcasts {action:?}", self.i);
 
         let msg = Message {
-            id: self.id.clone(),
-            proposer: self.j,
+            id: self.tag.domain.clone(),
+            proposer: self.tag.proposer,
             action,
         };
         let data = bincode::serialize(&msg)?;
         self.broadcaster
             .borrow_mut()
-            .broadcast(MODULE_NAME, Some(self.j), data);
+            .broadcast(MODULE_NAME, Some(self.tag.proposer), data);
         self.receive_message(self.i, msg)?;
         Ok(())
     }
@@ -606,23 +600,13 @@ impl Abba {
     // pre_vote_bytes_to_sign generates bytes for Pre-Vote signature share.
     // pre_vote_bytes_to_sign is same as serialized of $(ID, pre-vote, r, b)$ in spec.
     fn pre_vote_bytes_to_sign(&self, round: usize, v: &Value) -> Result<Vec<u8>> {
-        Ok(bincode::serialize(&(
-            self.id.clone(),
-            "pre-vote",
-            round,
-            v,
-        ))?)
+        Ok(bincode::serialize(&(&self.tag, "pre-vote", round, v))?)
     }
 
     // main_vote_bytes_to_sign generates bytes for Main-Vote signature share.
     // main_vote_bytes_to_sign is same as serialized of $(ID, main-vote, r, v)$ in spec.
     fn main_vote_bytes_to_sign(&self, round: usize, v: &MainVoteValue) -> Result<Vec<u8>> {
-        Ok(bincode::serialize(&(
-            self.id.clone(),
-            "main-vote",
-            round,
-            v,
-        ))?)
+        Ok(bincode::serialize(&(&self.tag, "main-vote", round, v))?)
     }
 
     // threshold return the threshold of the public key set.

--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -406,17 +406,10 @@ impl Abba {
     }
 
     fn check_message(&self, initiator: &NodeId, msg: &Message) -> Result<()> {
-        if msg.id != self.tag.domain {
+        if msg.tag != self.tag {
             return Err(Error::InvalidMessage(format!(
-                "invalid domain. expected: {}, got {}",
-                self.tag.domain, msg.id
-            )));
-        }
-
-        if msg.proposer != self.tag.proposer {
-            return Err(Error::InvalidMessage(format!(
-                "invalid proposer. expected: {}, got {}",
-                self.tag.proposer, msg.proposer
+                "invalid tag. expected: {}, got {}",
+                self.tag, msg.tag
             )));
         }
 
@@ -585,8 +578,7 @@ impl Abba {
         log::debug!("party {} broadcasts {action:?}", self.i);
 
         let msg = Message {
-            id: self.tag.domain.clone(),
-            proposer: self.tag.proposer,
+            tag: self.tag.clone(),
             action,
         };
         let data = bincode::serialize(&msg)?;

--- a/src/mvba/abba/mod.rs
+++ b/src/mvba/abba/mod.rs
@@ -15,7 +15,7 @@ use self::message::{
     PreVoteJustification, Value,
 };
 use super::hash::Hash32;
-use super::vcbc::message::Tag;
+use super::tag::Tag;
 use super::NodeId;
 use crate::mvba::abba::message::MainVoteJustification;
 use crate::mvba::broadcaster::Broadcaster;

--- a/src/mvba/abba/tests.rs
+++ b/src/mvba/abba/tests.rs
@@ -200,8 +200,13 @@ fn test_ignore_messages_with_wrong_proposer() {
     pre_vote_x.tag.proposer = TestNet::PARTY_B;
 
     let result = t.abba.receive_message(TestNet::PARTY_B, pre_vote_x);
-    assert!(matches!(result, Err(Error::InvalidMessage(msg))
-        if msg == format!("invalid tag. expected: test-domain.{j}.0, got test-domain.2.0")));
+    match result {
+        Err(Error::InvalidMessage(msg)) => assert_eq!(
+            msg,
+            "invalid tag. expected: test-domain[0].0, got test-domain[0].2"
+        ),
+        res => panic!("Should not have accepted the message: {res:?}"),
+    }
 }
 
 #[test]

--- a/src/mvba/abba/tests.rs
+++ b/src/mvba/abba/tests.rs
@@ -13,7 +13,7 @@ use super::{
     Abba,
 };
 use crate::mvba::hash::Hash32;
-use crate::mvba::vcbc::message::Tag;
+use crate::mvba::tag::Tag;
 use crate::mvba::{broadcaster::Broadcaster, bundle::Bundle, NodeId};
 
 struct TestNet {

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -13,7 +13,7 @@ use blsttc::{PublicKeySet, SecretKeyShare};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 pub struct Consensus {
-    id: String,
+    domain: String,
     self_id: NodeId,
     abba_map: HashMap<NodeId, Abba>,
     vcbc_map: HashMap<NodeId, Vcbc>,
@@ -25,7 +25,7 @@ pub struct Consensus {
 
 impl Consensus {
     pub fn init(
-        id: String,
+        domain: String,
         self_id: NodeId,
         sec_key_share: SecretKeyShare,
         pub_key_set: PublicKeySet,
@@ -39,7 +39,7 @@ impl Consensus {
 
         for party in &parties {
             let vcbc = Vcbc::new(
-                id.clone(),
+                domain.clone(),
                 self_id,
                 *party,
                 pub_key_set.clone(),
@@ -50,7 +50,7 @@ impl Consensus {
             vcbc_map.insert(*party, vcbc);
 
             let abba = Abba::new(
-                id.clone(),
+                domain.clone(),
                 self_id,
                 *party,
                 pub_key_set.clone(),
@@ -61,7 +61,7 @@ impl Consensus {
         }
 
         let mvba = Mvba::new(
-            id.clone(),
+            domain.clone(),
             self_id,
             sec_key_share,
             pub_key_set,
@@ -70,7 +70,7 @@ impl Consensus {
         );
 
         Consensus {
-            id,
+            domain,
             self_id,
             vcbc_map,
             abba_map,
@@ -144,7 +144,7 @@ impl Consensus {
                                 } else {
                                     // abba is finished but still we don't have the proposal
                                     // request it from the initiator
-                                    let data = vcbc::make_c_request_message(&self.id, target)?;
+                                    let data = vcbc::make_c_request_message(&self.domain, target)?;
 
                                     self.broadcaster.borrow_mut().broadcast(
                                         vcbc::MODULE_NAME,

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -5,7 +5,7 @@ use super::{
     error::Result,
     hash::Hash32,
     mvba::{self, Mvba},
-    vcbc::{self},
+    vcbc::{self, message::Tag},
     Proposal,
 };
 use crate::mvba::{broadcaster::Broadcaster, vcbc::Vcbc, MessageValidity, NodeId};
@@ -144,7 +144,8 @@ impl Consensus {
                                 } else {
                                     // abba is finished but still we don't have the proposal
                                     // request it from the initiator
-                                    let data = vcbc::make_c_request_message(&self.domain, target)?;
+                                    let tag = Tag::new(&self.domain, target, 0);
+                                    let data = vcbc::make_c_request_message(tag)?;
 
                                     self.broadcaster.borrow_mut().broadcast(
                                         vcbc::MODULE_NAME,

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -5,8 +5,8 @@ use super::{
     error::Result,
     hash::Hash32,
     mvba::{self, Mvba},
-    vcbc::{self, message::Tag},
-    Proposal,
+    tag::Tag,
+    vcbc, Proposal,
 };
 use crate::mvba::{broadcaster::Broadcaster, vcbc::Vcbc, MessageValidity, NodeId};
 use blsttc::{PublicKeySet, SecretKeyShare};

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -14,6 +14,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 pub struct Consensus {
     domain: String,
+    seq: usize,
     self_id: NodeId,
     abba_map: HashMap<NodeId, Abba>,
     vcbc_map: HashMap<NodeId, Vcbc>,
@@ -26,6 +27,7 @@ pub struct Consensus {
 impl Consensus {
     pub fn init(
         domain: String,
+        seq: usize,
         self_id: NodeId,
         sec_key_share: SecretKeyShare,
         pub_key_set: PublicKeySet,
@@ -38,7 +40,7 @@ impl Consensus {
         let mut vcbc_map = HashMap::new();
 
         for party in &parties {
-            let tag = Tag::new(&domain, *party, 0);
+            let tag = Tag::new(&domain, *party, seq);
             let vcbc = Vcbc::new(
                 tag.clone(),
                 self_id,
@@ -61,6 +63,7 @@ impl Consensus {
 
         let mvba = Mvba::new(
             domain.clone(),
+            seq,
             self_id,
             sec_key_share,
             pub_key_set,
@@ -70,6 +73,7 @@ impl Consensus {
 
         Consensus {
             domain,
+            seq,
             self_id,
             vcbc_map,
             abba_map,
@@ -143,7 +147,7 @@ impl Consensus {
                                 } else {
                                     // abba is finished but still we don't have the proposal
                                     // request it from the initiator
-                                    let tag = Tag::new(&self.domain, target, 0);
+                                    let tag = Tag::new(&self.domain, target, self.seq);
                                     let data = vcbc::make_c_request_message(tag)?;
 
                                     self.broadcaster.borrow_mut().broadcast(
@@ -239,6 +243,7 @@ mod tests {
             for p in &parties {
                 let consensus = Consensus::init(
                     id.clone(),
+                    0,
                     *p,
                     sec_key_set.secret_key_share(p),
                     sec_key_set.public_keys(),

--- a/src/mvba/consensus.rs
+++ b/src/mvba/consensus.rs
@@ -38,10 +38,10 @@ impl Consensus {
         let mut vcbc_map = HashMap::new();
 
         for party in &parties {
+            let tag = Tag::new(&domain, *party, 0);
             let vcbc = Vcbc::new(
-                domain.clone(),
+                tag.clone(),
                 self_id,
-                *party,
                 pub_key_set.clone(),
                 sec_key_share.clone(),
                 message_validity,
@@ -50,9 +50,8 @@ impl Consensus {
             vcbc_map.insert(*party, vcbc);
 
             let abba = Abba::new(
-                domain.clone(),
+                tag,
                 self_id,
-                *party,
                 pub_key_set.clone(),
                 sec_key_share.clone(),
                 broadcaster_rc.clone(),

--- a/src/mvba/mod.rs
+++ b/src/mvba/mod.rs
@@ -1,6 +1,7 @@
 pub mod consensus;
 pub mod error;
 pub mod hash;
+pub mod tag;
 
 mod abba;
 mod broadcaster;

--- a/src/mvba/mvba/message.rs
+++ b/src/mvba/mvba/message.rs
@@ -2,14 +2,13 @@ use blsttc::{Signature, SignatureShare};
 use serde::{Deserialize, Serialize};
 
 use super::NodeId;
-use crate::mvba::hash::Hash32;
+use crate::mvba::{hash::Hash32, vcbc::message::Tag};
 
 /// VoteAction definition.
 /// This is same as `v-vote` message in spec: (ID, v-vote, a, uj, ρj)
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Vote {
-    pub id: String,                         // this is same as $id$ in spec
-    pub proposer: NodeId,                   // this is same as $a$ in spec
+    pub tag: Tag,                           // this is same as $id.a.s$ in spec
     pub value: bool,                        // this is same as $0$ or $1$ in spec
     pub proof: Option<(Hash32, Signature)>, // this is same as $ρ$ in spec
 }

--- a/src/mvba/mvba/message.rs
+++ b/src/mvba/mvba/message.rs
@@ -2,7 +2,7 @@ use blsttc::{Signature, SignatureShare};
 use serde::{Deserialize, Serialize};
 
 use super::NodeId;
-use crate::mvba::{hash::Hash32, vcbc::message::Tag};
+use crate::mvba::{hash::Hash32, tag::Tag};
 
 /// VoteAction definition.
 /// This is same as `v-vote` message in spec: (ID, v-vote, a, uj, ρj)

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -14,7 +14,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 pub(crate) const MODULE_NAME: &str = "mvba";
 
 pub struct Mvba {
-    id: String,      // this is same as $ID$ in spec
+    domain: String,  // this is same as $ID$ in spec
     i: NodeId,       // this is same as $i$ in spec
     l: usize,        // this is same as $a$ in spec
     v: Option<bool>, // this is same as $v$ in spec
@@ -37,7 +37,7 @@ impl Mvba {
         broadcaster: Rc<RefCell<Broadcaster>>,
     ) -> Self {
         Self {
-            id,
+            domain: id,
             i: self_id,
             l: 0,
             v: None,
@@ -58,8 +58,7 @@ impl Mvba {
         signature: Signature,
     ) -> Result<()> {
         debug_assert!(self.parties.contains(&proposer));
-
-        let tag = Tag::new(&self.id, proposer, 0); // TODO: this should be self.tag
+        let tag = Tag::new(&self.domain, proposer, 0); // TODO: this should be self.tag
         let digest = Hash32::calculate(&proposal);
         let sign_bytes = vcbc::c_ready_bytes_to_sign(&tag, &digest)?;
         if !self.pub_key_set.public_key().verify(&signature, sign_bytes) {
@@ -90,6 +89,11 @@ impl Mvba {
         Ok(true)
     }
 
+    pub fn tag(&self) -> Tag {
+        let proposer = self.current_proposer();
+        Tag::new(&self.domain, proposer, 0)
+    }
+
     pub fn current_proposer(&self) -> NodeId {
         *self.parties.get(self.l).unwrap()
     }
@@ -103,10 +107,11 @@ impl Mvba {
     }
 
     fn check_message(&mut self, msg: &Message) -> Result<()> {
-        if msg.vote.id != self.id {
+        let tag = self.tag();
+        if msg.vote.tag != tag {
             return Err(Error::InvalidMessage(format!(
-                "invalid ID. expected: {}, got {}",
-                self.id, msg.vote.id
+                "invalid tag. expected: {tag}, got {}",
+                msg.vote.tag
             )));
         }
 
@@ -128,8 +133,7 @@ impl Mvba {
         }
 
         if let Some((digest, signature)) = &msg.vote.proof {
-            let tag = Tag::new(&self.id, msg.vote.proposer, 0); // TODO: I think this is a bug, shouldn't this be self.tag
-            let sign_bytes = vcbc::c_ready_bytes_to_sign(&tag, digest).unwrap();
+            let sign_bytes = vcbc::c_ready_bytes_to_sign(&self.tag(), digest).unwrap();
             if !self.pub_key_set.public_key().verify(signature, sign_bytes) {
                 return Err(Error::InvalidMessage(
                     "proposal with an invalid proof".to_string(),
@@ -141,7 +145,7 @@ impl Mvba {
     }
 
     pub fn add_vote(&mut self, msg: &Message) -> Result<bool> {
-        let votes = self.must_get_proposer_votes(&msg.vote.proposer);
+        let votes = self.must_get_proposer_votes(&msg.vote.tag.proposer);
         if let Some(exist) = votes.get(&msg.voter) {
             if exist != &msg.vote {
                 return Err(Error::InvalidMessage(format!(
@@ -154,7 +158,7 @@ impl Mvba {
 
         votes.insert(msg.voter, msg.vote.clone());
 
-        if msg.vote.value && !self.proposals.contains_key(&msg.vote.proposer) {
+        if msg.vote.value && !self.proposals.contains_key(&msg.vote.tag.proposer) {
             // If a v-vote from Pj indicates 1 but Pi has not yet received Pa ’s proposal,
             // ignore the vote and ask Pj to supply Pa ’s proposal
             // (by sending it the message (ID|vcbc.a.0, c-request)).
@@ -164,12 +168,11 @@ impl Mvba {
                 self.i,
                 msg.vote.proposer,
             );
-            let tag = Tag::new(&self.id, msg.vote.proposer, 0); // TODO: should this vote.proposer be self.j?
-            let data = vcbc::make_c_request_message(tag)?;
+            let data = vcbc::make_c_request_message(self.tag())?;
 
             self.broadcaster.borrow_mut().send_to(
                 vcbc::MODULE_NAME,
-                Some(msg.vote.proposer),
+                Some(msg.vote.tag.proposer),
                 data,
                 msg.voter,
             );
@@ -189,19 +192,13 @@ impl Mvba {
             return Ok(());
         }
 
-        // Message is for another proposal, not current one
-        // TODO: test me!
-        if msg.vote.proposer != self.current_proposer() {
-            return Ok(());
-        }
-
         // wait for n − t messages (v-echo, wj , πj ) to be c-delivered with tag ID|vcbc.j.0
         //from distinct Pj such that QID (wj , πj ) holds
         let threshold = self.threshold();
         if self.proposals.len() >= threshold && self.v.is_none() {
             // wait for n − t messages (ID, v-vote, a, uj , ρj ) from distinct Pj such
             // that VID|a (uj , ρj) holds
-            let votes = self.must_get_proposer_votes(&msg.vote.proposer);
+            let votes = self.must_get_proposer_votes(&msg.vote.tag.proposer);
             if votes.len() >= threshold {
                 if votes.values().any(|v| v.value) {
                     log::debug!(
@@ -230,18 +227,18 @@ impl Mvba {
         }
         self.votes_per_proposer.get_mut(proposer).unwrap()
     }
+
     fn vote(&mut self) -> Result<()> {
         // wait for n − t messages (v-echo, wj , πj ) to be c-delivered with tag ID|vcbc.j.0
         //from distinct Pj such that QID (wj , πj ) holds
         if self.proposals.len() >= self.threshold() && !self.voted {
-            let a = self.current_proposer();
-            let vote = match self.proposals.get(&a) {
+            let tag = self.tag();
+            let vote = match self.proposals.get(&tag.proposer) {
                 None => {
                     // if wa = ⊥ then
                     // send the message (ID, v-vote, a, 0, ⊥) to all parties
                     Vote {
-                        id: self.id.clone(),
-                        proposer: a,
+                        tag,
                         value: false,
                         proof: None,
                     }
@@ -252,8 +249,7 @@ impl Mvba {
                     // send the message (ID, v-vote, a, 1, ρ) to all parties
                     let digest = Hash32::calculate(proposal);
                     Vote {
-                        id: self.id.clone(),
-                        proposer: a,
+                        tag,
                         value: true,
                         proof: Some((digest, signature.clone())),
                     }

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -170,7 +170,7 @@ impl Mvba {
             log::debug!(
                 "party {} requests proposal from {}",
                 self.i,
-                msg.vote.proposer,
+                msg.vote.tag.proposer,
             );
             let data = vcbc::make_c_request_message(self.current_tag())?;
 

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -111,11 +111,10 @@ impl Mvba {
     }
 
     fn check_message(&mut self, msg: &Message) -> Result<()> {
-        let tag = self.current_tag();
-        if msg.vote.tag != tag {
+        if msg.vote.tag.domain != self.domain {
             return Err(Error::InvalidMessage(format!(
-                "invalid tag. expected: {tag}, got {}",
-                msg.vote.tag
+                "invalid domain. expected: {}, got {}",
+                self.domain, msg.vote.tag.domain
             )));
         }
 

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -4,6 +4,7 @@ mod message;
 use self::message::{Message, Vote};
 
 use self::{error::Error, error::Result};
+use super::tag::Domain;
 use super::vcbc;
 use super::{hash::Hash32, Proposal};
 use crate::mvba::tag::Tag;
@@ -14,8 +15,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 pub(crate) const MODULE_NAME: &str = "mvba";
 
 pub struct Mvba {
-    domain: String,  // this is same as $ID$ in spec
-    seq: usize,      // this is same as $s$ in spec
+    domain: Domain,  // this is same as $ID.s$ in spec
     i: NodeId,       // this is same as $i$ in spec
     l: usize,        // this is same as $a$ in spec
     v: Option<bool>, // this is same as $v$ in spec
@@ -30,8 +30,7 @@ pub struct Mvba {
 
 impl Mvba {
     pub fn new(
-        domain: String,
-        seq: usize,
+        domain: Domain,
         self_id: NodeId,
         sec_key_share: SecretKeyShare,
         pub_key_set: PublicKeySet,
@@ -40,7 +39,6 @@ impl Mvba {
     ) -> Self {
         Self {
             domain,
-            seq,
             i: self_id,
             l: 0,
             v: None,
@@ -97,7 +95,7 @@ impl Mvba {
     }
 
     pub fn build_tag(&self, proposer: NodeId) -> Tag {
-        Tag::new(&self.domain, proposer, self.seq)
+        Tag::new(self.domain.clone(), proposer)
     }
 
     pub fn current_proposer(&self) -> NodeId {

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -136,7 +136,7 @@ impl Mvba {
         }
 
         if let Some((digest, signature)) = &msg.vote.proof {
-            let sign_bytes = vcbc::c_ready_bytes_to_sign(&self.current_tag(), digest).unwrap();
+            let sign_bytes = vcbc::c_ready_bytes_to_sign(&msg.vote.tag, digest).unwrap();
             if !self.pub_key_set.public_key().verify(signature, sign_bytes) {
                 return Err(Error::InvalidMessage(
                     "proposal with an invalid proof".to_string(),

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -164,7 +164,8 @@ impl Mvba {
                 self.i,
                 msg.vote.proposer,
             );
-            let data = vcbc::make_c_request_message(&self.id, msg.vote.proposer)?;
+            let tag = Tag::new(&self.id, msg.vote.proposer, 0); // TODO: should this vote.proposer be self.j?
+            let data = vcbc::make_c_request_message(tag)?;
 
             self.broadcaster.borrow_mut().send_to(
                 vcbc::MODULE_NAME,

--- a/src/mvba/mvba/mod.rs
+++ b/src/mvba/mvba/mod.rs
@@ -6,7 +6,7 @@ use self::message::{Message, Vote};
 use self::{error::Error, error::Result};
 use super::vcbc;
 use super::{hash::Hash32, Proposal};
-use crate::mvba::vcbc::message::Tag;
+use crate::mvba::tag::Tag;
 use crate::mvba::{broadcaster::Broadcaster, NodeId};
 use blsttc::{PublicKeySet, SecretKeyShare, Signature};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};

--- a/src/mvba/mvba/tests.rs
+++ b/src/mvba/mvba/tests.rs
@@ -3,6 +3,7 @@ use super::NodeId;
 use super::{Error, Mvba};
 use crate::mvba::broadcaster::Broadcaster;
 use crate::mvba::hash::Hash32;
+use crate::mvba::vcbc::message::Tag;
 use crate::mvba::{vcbc, Proposal};
 use blsttc::{SecretKey, SecretKeySet, Signature, SignatureShare};
 use rand::{thread_rng, Rng};
@@ -38,7 +39,8 @@ impl TestNet {
         for p in &parties {
             let proposal = (0..100).map(|_| rng.gen_range(0..64)).collect();
             let digest = Hash32::calculate(&proposal);
-            let proposal_sign_bytes = vcbc::c_ready_bytes_to_sign(&id, p, &digest).unwrap();
+            let tag = Tag::new(&id, *p, 0);
+            let proposal_sign_bytes = vcbc::c_ready_bytes_to_sign(&tag, &digest).unwrap();
             let sig = sec_key_set.secret_key().sign(proposal_sign_bytes);
 
             proposals.insert(*p, (proposal, sig));

--- a/src/mvba/mvba/tests.rs
+++ b/src/mvba/mvba/tests.rs
@@ -106,8 +106,15 @@ fn test_ignore_messages_with_wrong_id() {
     msg.vote.tag.domain = Domain::new("another-domain", 0);
 
     let result = t.mvba.receive_message(msg);
-    assert!(matches!(result, Err(Error::InvalidMessage(msg))
-        if msg == "invalid tag. expected: test-domain[0].0, got another-domain[0].0"));
+    match result {
+        Err(Error::InvalidMessage(msg)) => {
+            assert_eq!(
+                msg,
+                "invalid domain. expected: test-domain[0], got another-domain[0]"
+            )
+        }
+        res => panic!("Unexpected result: {res:?}"),
+    }
 }
 
 #[test]

--- a/src/mvba/mvba/tests.rs
+++ b/src/mvba/mvba/tests.rs
@@ -287,7 +287,8 @@ fn test_request_proposal() {
 
     t.mvba.receive_message(msg_x).unwrap();
 
-    let data = vcbc::make_c_request_message(&t.mvba.id, TestNet::PARTY_X).unwrap();
+    let tag = Tag::new(t.mvba.id, TestNet::PARTY_X, 0);
+    let data = vcbc::make_c_request_message(tag).unwrap();
 
     assert!(t
         .broadcaster

--- a/src/mvba/mvba/tests.rs
+++ b/src/mvba/mvba/tests.rs
@@ -3,7 +3,7 @@ use super::NodeId;
 use super::{Error, Mvba};
 use crate::mvba::broadcaster::Broadcaster;
 use crate::mvba::hash::Hash32;
-use crate::mvba::vcbc::message::Tag;
+use crate::mvba::tag::Tag;
 use crate::mvba::{vcbc, Proposal};
 use blsttc::{SecretKey, SecretKeySet, Signature, SignatureShare};
 use rand::{thread_rng, Rng};
@@ -28,7 +28,7 @@ impl TestNet {
     // The MVBA test instance creates for party `i` with `ID` sets to `test-id`
     // and `tag.s` sets to `0`.
     pub fn new(i: NodeId) -> Self {
-        let id = "test-id".to_string();
+        let domain = "test-domain".to_string();
         let mut rng = thread_rng();
         let sec_key_set = SecretKeySet::random(2, &mut rng);
         let sec_key_share = sec_key_set.secret_key_share(i);
@@ -39,7 +39,7 @@ impl TestNet {
         for p in &parties {
             let proposal = (0..100).map(|_| rng.gen_range(0..64)).collect();
             let digest = Hash32::calculate(&proposal);
-            let tag = Tag::new(&id, *p, 0);
+            let tag = Tag::new(&domain, *p, 0);
             let proposal_sign_bytes = vcbc::c_ready_bytes_to_sign(&tag, &digest).unwrap();
             let sig = sec_key_set.secret_key().sign(proposal_sign_bytes);
 
@@ -47,7 +47,7 @@ impl TestNet {
         }
 
         let mvba = Mvba::new(
-            id,
+            domain,
             i,
             sec_key_share,
             sec_key_set.public_keys(),

--- a/src/mvba/tag.rs
+++ b/src/mvba/tag.rs
@@ -34,9 +34,6 @@ impl Display for Tag {
 
 impl Tag {
     pub fn new(domain: Domain, proposer: usize) -> Self {
-        Self {
-            domain: domain.into(),
-            proposer,
-        }
+        Self { domain, proposer }
     }
 }

--- a/src/mvba/tag.rs
+++ b/src/mvba/tag.rs
@@ -3,24 +3,40 @@ use std::fmt::Display;
 use super::NodeId;
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Domain {
+    pub id: String, // this is same as $ID$ in spec
+    pub seq: usize, // this is same as $s$ in spec
+}
+
+impl Domain {
+    pub fn new(id: impl Into<String>, seq: usize) -> Self {
+        Self { id: id.into(), seq }
+    }
+}
+
+impl Display for Domain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}[{}]", self.id, self.seq)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tag {
-    pub domain: String,   // this is same as $id$ in spec
+    pub domain: Domain,   // this is same as $ID.s$ in spec
     pub proposer: NodeId, // this is same as $j$ in spec
-    pub s: usize,         // this is same as $s$ in spec
 }
 
 impl Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.domain, self.proposer, self.s)
+        write!(f, "{}.{}", self.domain, self.proposer)
     }
 }
 
 impl Tag {
-    pub fn new(domain: impl Into<String>, proposer: usize, s: usize) -> Self {
+    pub fn new(domain: Domain, proposer: usize) -> Self {
         Self {
             domain: domain.into(),
             proposer,
-            s,
         }
     }
 }

--- a/src/mvba/tag.rs
+++ b/src/mvba/tag.rs
@@ -1,0 +1,26 @@
+use std::fmt::Display;
+
+use super::NodeId;
+
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Tag {
+    pub domain: String,   // this is same as $id$ in spec
+    pub proposer: NodeId, // this is same as $j$ in spec
+    pub s: usize,         // this is same as $s$ in spec
+}
+
+impl Display for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.domain, self.proposer, self.s)
+    }
+}
+
+impl Tag {
+    pub fn new(domain: impl Into<String>, proposer: usize, s: usize) -> Self {
+        Self {
+            domain: domain.into(),
+            proposer,
+            s,
+        }
+    }
+}

--- a/src/mvba/tag.rs
+++ b/src/mvba/tag.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use super::NodeId;
 
@@ -20,7 +20,7 @@ impl Display for Domain {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tag {
     pub domain: Domain,   // this is same as $ID.s$ in spec
     pub proposer: NodeId, // this is same as $j$ in spec
@@ -29,6 +29,12 @@ pub struct Tag {
 impl Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.domain, self.proposer)
+    }
+}
+
+impl Debug for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Tag as Display>::fmt(self, f)
     }
 }
 

--- a/src/mvba/vcbc/message.rs
+++ b/src/mvba/vcbc/message.rs
@@ -1,18 +1,18 @@
-use crate::mvba::{hash::Hash32, Proposal};
+use crate::mvba::{hash::Hash32, NodeId, Proposal};
 use blsttc::{Signature, SignatureShare};
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tag {
-    pub id: String, // this is same as $id$ in spec
-    pub j: usize,   // this is same as $j$ in spec
-    pub s: usize,   // this is same as $s$ in spec
+    pub id: String,       // this is same as $id$ in spec
+    pub proposer: NodeId, // this is same as $j$ in spec
+    pub s: usize,         // this is same as $s$ in spec
 }
 
 impl Tag {
-    pub fn new(id: &str, j: usize, s: usize) -> Self {
+    pub fn new(id: impl Into<String>, proposer: usize, s: usize) -> Self {
         Self {
-            id: id.to_string(),
-            j,
+            id: id.into(),
+            proposer,
             s,
         }
     }

--- a/src/mvba/vcbc/message.rs
+++ b/src/mvba/vcbc/message.rs
@@ -3,15 +3,15 @@ use blsttc::{Signature, SignatureShare};
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tag {
-    pub id: String,       // this is same as $id$ in spec
+    pub domain: String,   // this is same as $id$ in spec
     pub proposer: NodeId, // this is same as $j$ in spec
     pub s: usize,         // this is same as $s$ in spec
 }
 
 impl Tag {
-    pub fn new(id: impl Into<String>, proposer: usize, s: usize) -> Self {
+    pub fn new(domain: impl Into<String>, proposer: usize, s: usize) -> Self {
         Self {
-            id: id.into(),
+            domain: domain.into(),
             proposer,
             s,
         }

--- a/src/mvba/vcbc/message.rs
+++ b/src/mvba/vcbc/message.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::mvba::{hash::Hash32, NodeId, Proposal};
 use blsttc::{Signature, SignatureShare};
 
@@ -6,6 +8,12 @@ pub struct Tag {
     pub domain: String,   // this is same as $id$ in spec
     pub proposer: NodeId, // this is same as $j$ in spec
     pub s: usize,         // this is same as $s$ in spec
+}
+
+impl Display for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.domain, self.proposer, self.s)
+    }
 }
 
 impl Tag {

--- a/src/mvba/vcbc/message.rs
+++ b/src/mvba/vcbc/message.rs
@@ -1,30 +1,5 @@
-use std::fmt::Display;
-
-use crate::mvba::{hash::Hash32, NodeId, Proposal};
+use crate::mvba::{hash::Hash32, tag::Tag, Proposal};
 use blsttc::{Signature, SignatureShare};
-
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Tag {
-    pub domain: String,   // this is same as $id$ in spec
-    pub proposer: NodeId, // this is same as $j$ in spec
-    pub s: usize,         // this is same as $s$ in spec
-}
-
-impl Display for Tag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.domain, self.proposer, self.s)
-    }
-}
-
-impl Tag {
-    pub fn new(domain: impl Into<String>, proposer: usize, s: usize) -> Self {
-        Self {
-            domain: domain.into(),
-            proposer,
-            s,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Action {

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -25,7 +25,7 @@ pub fn make_c_request_message(
     let msg = Message {
         tag: Tag {
             id: id.to_string(),
-            j: proposer,
+            proposer,
             s: 0,
         },
         action: Action::Request,
@@ -34,7 +34,7 @@ pub fn make_c_request_message(
 }
 
 // c_ready_bytes_to_sign generates bytes that should be signed by each party
-// as a wittiness of receiving the message.
+// as a witness of receiving the message.
 // c_ready_bytes_to_sign is same as serialized of $(ID.j.s, c-ready, H(m))$ in spec
 pub fn c_ready_bytes_to_sign(
     id: &str,
@@ -107,7 +107,7 @@ impl Vcbc {
     /// c_broadcast sends the messages `m` to all other parties.
     /// It also adds the message to message_log and process it.
     pub fn c_broadcast(&mut self, m: Proposal) -> Result<()> {
-        debug_assert_eq!(self.i, self.tag.j);
+        debug_assert_eq!(self.i, self.tag.proposer);
 
         // Upon receiving message (ID.j.s, in, c-broadcast, m):
         // send (ID.j.s, c-send, m) to all parties
@@ -139,7 +139,7 @@ impl Vcbc {
             Action::Send(m) => {
                 // Upon receiving message (ID.j.s, c-send, m) from Pl:
                 // if j = l and m̄ = ⊥ then
-                if initiator == self.tag.j && self.m_bar.is_none() {
+                if initiator == self.tag.proposer && self.m_bar.is_none() {
                     if !(self.message_validity)(initiator, &m) {
                         return Err(Error::InvalidMessage("invalid proposal".to_string()));
                     }
@@ -150,7 +150,7 @@ impl Vcbc {
                     self.d = Some(d);
 
                     // compute an S1-signature share ν on (ID.j.s, c-ready, H(m))
-                    let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.j, &d)?;
+                    let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.proposer, &d)?;
                     let s1 = self.sec_key_share.sign(sign_bytes);
 
                     let ready_msg = Message {
@@ -159,7 +159,7 @@ impl Vcbc {
                     };
 
                     // send (ID.j.s, c-ready, H(m), ν) to Pj
-                    self.send_to(ready_msg, self.tag.j)?;
+                    self.send_to(ready_msg, self.tag.proposer)?;
                 }
             }
             Action::Ready(msg_d, sig_share) => {
@@ -167,7 +167,7 @@ impl Vcbc {
                     Some(d) => d,
                     None => return Err(Error::Generic("protocol violated. no digest".to_string())),
                 };
-                let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.j, &d)?;
+                let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.proposer, &d)?;
 
                 if d != msg_d {
                     log::warn!("party {} received c-ready with unknown digest. expected {d:?}, got {msg_d:?}", self.i);
@@ -189,7 +189,7 @@ impl Vcbc {
                     }
 
                     // if i = j and νl is a valid S1-signature share then
-                    if self.i == msg.tag.j && valid_sig {
+                    if self.i == msg.tag.proposer && valid_sig {
                         // Wd ← Wd ∪ {νl}
                         e.insert(sig_share);
 
@@ -234,7 +234,7 @@ impl Vcbc {
                     }
                 };
 
-                let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.j, &d)?;
+                let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.proposer, &d)?;
                 let valid_sig = self.pub_key_set.public_key().verify(&sig, sign_bytes);
                 if !valid_sig {
                     log::warn!(
@@ -272,7 +272,7 @@ impl Vcbc {
                 if self.u_bar.is_none() {
                     // if µ̄ = ⊥ and ...
                     let d = Hash32::calculate(&m);
-                    let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.j, &d)?;
+                    let sign_bytes = c_ready_bytes_to_sign(&self.tag.id, &self.tag.proposer, &d)?;
                     if self.pub_key_set.public_key().verify(&u, sign_bytes) {
                         // ... µ is a valid S1 -signature on (ID.j.s, c-ready, H(m)) then
                         // µ̄ ← µ
@@ -310,7 +310,7 @@ impl Vcbc {
         } else {
             self.broadcaster
                 .borrow_mut()
-                .send_to(MODULE_NAME, Some(self.tag.j), data, to);
+                .send_to(MODULE_NAME, Some(self.tag.proposer), data, to);
         }
         Ok(())
     }

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -68,17 +68,14 @@ fn try_insert(map: &mut HashMap<NodeId, Message>, k: NodeId, v: Message) -> Resu
 
 impl Vcbc {
     pub fn new(
-        id: String,
+        tag: Tag,
         self_id: NodeId,
-        proposer: NodeId,
         pub_key_set: PublicKeySet,
         sec_key_share: SecretKeyShare,
         message_validity: MessageValidity,
         broadcaster: Rc<RefCell<Broadcaster>>,
     ) -> Self {
         debug_assert_eq!(self_id, broadcaster.borrow().self_id());
-
-        let tag = Tag::new(&id, proposer, 0);
 
         Self {
             tag,

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -37,11 +37,10 @@ pub fn make_c_request_message(
 // as a witness of receiving the message.
 // c_ready_bytes_to_sign is same as serialized of $(ID.j.s, c-ready, H(m))$ in spec
 pub fn c_ready_bytes_to_sign(
-    domain: &str,
-    proposer: &NodeId,
+    tag: &Tag,
     digest: &Hash32,
 ) -> std::result::Result<Vec<u8>, bincode::Error> {
-    bincode::serialize(&(domain, proposer, 0, "c-ready", digest))
+    bincode::serialize(&(tag, "c-ready", digest))
 }
 
 // Protocol VCBC for verifiable and authenticated consistent broadcast.
@@ -150,8 +149,7 @@ impl Vcbc {
                     self.d = Some(d);
 
                     // compute an S1-signature share ν on (ID.j.s, c-ready, H(m))
-                    let sign_bytes =
-                        c_ready_bytes_to_sign(&self.tag.domain, &self.tag.proposer, &d)?;
+                    let sign_bytes = c_ready_bytes_to_sign(&self.tag, &d)?;
                     let s1 = self.sec_key_share.sign(sign_bytes);
 
                     let ready_msg = Message {
@@ -168,7 +166,7 @@ impl Vcbc {
                     Some(d) => d,
                     None => return Err(Error::Generic("protocol violated. no digest".to_string())),
                 };
-                let sign_bytes = c_ready_bytes_to_sign(&self.tag.domain, &self.tag.proposer, &d)?;
+                let sign_bytes = c_ready_bytes_to_sign(&self.tag, &d)?;
 
                 if d != msg_d {
                     log::warn!("party {} received c-ready with unknown digest. expected {d:?}, got {msg_d:?}", self.i);
@@ -235,7 +233,7 @@ impl Vcbc {
                     }
                 };
 
-                let sign_bytes = c_ready_bytes_to_sign(&self.tag.domain, &self.tag.proposer, &d)?;
+                let sign_bytes = c_ready_bytes_to_sign(&self.tag, &d)?;
                 let valid_sig = self.pub_key_set.public_key().verify(&sig, sign_bytes);
                 if !valid_sig {
                     log::warn!(
@@ -273,8 +271,7 @@ impl Vcbc {
                 if self.u_bar.is_none() {
                     // if µ̄ = ⊥ and ...
                     let d = Hash32::calculate(&m);
-                    let sign_bytes =
-                        c_ready_bytes_to_sign(&self.tag.domain, &self.tag.proposer, &d)?;
+                    let sign_bytes = c_ready_bytes_to_sign(&self.tag, &d)?;
                     if self.pub_key_set.public_key().verify(&u, sign_bytes) {
                         // ... µ is a valid S1 -signature on (ID.j.s, c-ready, H(m)) then
                         // µ̄ ← µ

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -18,16 +18,9 @@ pub(crate) const MODULE_NAME: &str = "vcbc";
 
 // make_c_request_message creates the payload message to request a proposal
 // from the the proposer
-pub fn make_c_request_message(
-    domain: &str,
-    proposer: NodeId,
-) -> std::result::Result<Vec<u8>, bincode::Error> {
+pub fn make_c_request_message(tag: Tag) -> std::result::Result<Vec<u8>, bincode::Error> {
     let msg = Message {
-        tag: Tag {
-            domain: domain.to_string(),
-            proposer,
-            s: 0,
-        },
+        tag,
         action: Action::Request,
     };
     bincode::serialize(&msg)

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -9,8 +9,9 @@ use std::rc::Rc;
 use blsttc::{PublicKeySet, SecretKeyShare, Signature, SignatureShare};
 
 use self::error::{Error, Result};
-use self::message::{Action, Message, Tag};
+use self::message::{Action, Message};
 use super::hash::Hash32;
+use super::tag::Tag;
 use super::{MessageValidity, NodeId, Proposal};
 use crate::mvba::broadcaster::Broadcaster;
 

--- a/src/mvba/vcbc/mod.rs
+++ b/src/mvba/vcbc/mod.rs
@@ -120,7 +120,7 @@ impl Vcbc {
 
         if msg.tag != self.tag {
             return Err(Error::InvalidMessage(format!(
-                "invalid tag. expected {:?}, got {:?}",
+                "invalid tag. expected {}, got {}",
                 self.tag, msg.tag
             )));
         }

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -1,4 +1,4 @@
-use super::message::{Action, Message};
+use super::message::{Action, Message, Tag};
 use super::Error;
 use super::{NodeId, Vcbc};
 use crate::mvba::broadcaster::Broadcaster;
@@ -134,10 +134,11 @@ fn test_vcbc_happy_path() {
     let proposer = 1;
     let mut net = Net::new(7, proposer);
 
+    let tag = Tag::new(&net.domain, proposer, 0);
+
     // Node 1 (the proposer) will initiate VCBC by broadcasting a value
 
-    let proposer_node = net.node_mut(proposer);
-    proposer_node
+    net.node_mut(proposer)
         .c_broadcast("HAPPY-PATH-VALUE".as_bytes().to_vec())
         .expect("Failed to c-broadcast");
 
@@ -149,12 +150,9 @@ fn test_vcbc_happy_path() {
 
     // And check that all nodes have delivered the expected value and signature
 
-    let expected_bytes_to_sign: Vec<u8> = c_ready_bytes_to_sign(
-        &net.domain,
-        &proposer,
-        &Hash32::calculate("HAPPY-PATH-VALUE"),
-    )
-    .expect("Failed to serialize");
+    let expected_bytes_to_sign: Vec<u8> =
+        c_ready_bytes_to_sign(&tag, &Hash32::calculate("HAPPY-PATH-VALUE"))
+            .expect("Failed to serialize");
 
     let expected_sig = net.secret_key_set.secret_key().sign(expected_bytes_to_sign);
 
@@ -195,9 +193,9 @@ fn prop_vcbc_terminates_under_randomized_msg_delivery(
 
     // And finally, check that all nodes have delivered the expected value and signature
 
+    let tag = Tag::new(&net.domain, proposer, 0);
     let expected_bytes_to_sign: Vec<u8> =
-        c_ready_bytes_to_sign(&net.domain, &proposer, &Hash32::calculate(&proposal))
-            .expect("Failed to serialize");
+        c_ready_bytes_to_sign(&tag, &Hash32::calculate(&proposal)).expect("Failed to serialize");
 
     let expected_sig = net.secret_key_set.secret_key().sign(expected_bytes_to_sign);
 
@@ -317,15 +315,12 @@ impl TestNet {
 
     // u is same as final signature
     pub fn u(&self) -> Signature {
-        let sign_bytes =
-            c_ready_bytes_to_sign(&self.vcbc.tag.domain, &self.vcbc.tag.proposer, &self.d())
-                .unwrap();
+        let sign_bytes = c_ready_bytes_to_sign(&self.vcbc.tag, &self.d()).unwrap();
         self.sec_key_set.secret_key().sign(sign_bytes)
     }
 
     fn sig_share(&self, digest: &Hash32, id: &NodeId) -> SignatureShare {
-        let sign_bytes =
-            c_ready_bytes_to_sign(&self.vcbc.tag.domain, &self.vcbc.tag.proposer, digest).unwrap();
+        let sign_bytes = c_ready_bytes_to_sign(&self.vcbc.tag, digest).unwrap();
         let sec_key_share = self.sec_key_set.secret_key_share(id);
 
         sec_key_share.sign(sign_bytes)

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -1,9 +1,10 @@
-use super::message::{Action, Message, Tag};
+use super::message::{Action, Message};
 use super::Error;
 use super::{NodeId, Vcbc};
 use crate::mvba::broadcaster::Broadcaster;
 use crate::mvba::bundle::Bundle;
 use crate::mvba::hash::Hash32;
+use crate::mvba::tag::Tag;
 use crate::mvba::vcbc::c_ready_bytes_to_sign;
 use crate::mvba::Proposal;
 use blsttc::{SecretKeySet, Signature, SignatureShare};

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -217,9 +217,14 @@ fn test_ignore_messages_with_invalid_tag() {
     let mut final_msg = t.make_final_msg(&t.d());
     final_msg.tag.domain = Domain::new("another-domain", 0);
 
-    let result = t.vcbc.receive_message(TestNet::PARTY_B, final_msg.clone());
-    assert!(matches!(result, Err(Error::InvalidMessage(msg))
-        if msg == "invalid tag. expected test-domain[0].0, got another-domain[0].0"));
+    let result = t.vcbc.receive_message(TestNet::PARTY_B, final_msg);
+    match result {
+        Err(Error::InvalidMessage(msg)) => assert_eq!(
+            msg,
+            "invalid tag. expected test-domain[0].0, got another-domain[0].0"
+        ),
+        res => panic!("Unexpected result: {res:?}"),
+    }
 }
 
 // --------------------------------------

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -315,13 +315,13 @@ impl TestNet {
     // u is same as final signature
     pub fn u(&self) -> Signature {
         let sign_bytes =
-            c_ready_bytes_to_sign(&self.vcbc.tag.id, &self.vcbc.tag.j, &self.d()).unwrap();
+            c_ready_bytes_to_sign(&self.vcbc.tag.id, &self.vcbc.tag.proposer, &self.d()).unwrap();
         self.sec_key_set.secret_key().sign(sign_bytes)
     }
 
     fn sig_share(&self, digest: &Hash32, id: &NodeId) -> SignatureShare {
         let sign_bytes =
-            c_ready_bytes_to_sign(&self.vcbc.tag.id, &self.vcbc.tag.j, digest).unwrap();
+            c_ready_bytes_to_sign(&self.vcbc.tag.id, &self.vcbc.tag.proposer, digest).unwrap();
         let sec_key_share = self.sec_key_set.secret_key_share(id);
 
         sec_key_share.sign(sign_bytes)

--- a/src/mvba/vcbc/tests.rs
+++ b/src/mvba/vcbc/tests.rs
@@ -44,10 +44,10 @@ impl Net {
         let nodes = BTreeMap::from_iter((1..=n).into_iter().map(|self_id| {
             let key_share = secret_key_set.secret_key_share(self_id);
             let broadcaster = Rc::new(RefCell::new(Broadcaster::new(self_id)));
+            let tag = Tag::new(&domain, proposer, 0);
             let vcbc = Vcbc::new(
-                domain.clone(),
+                tag,
                 self_id,
-                proposer,
                 public_key_set.clone(),
                 key_share,
                 valid_proposal,
@@ -243,15 +243,14 @@ impl TestNet {
     // The VCBC test instance creates for party `i` with `ID` sets to `test-id`
     // and `s` sets to `0`.
     pub fn new(i: NodeId, j: NodeId) -> Self {
-        let id = "test-id".to_string();
         let mut rng = thread_rng();
         let sec_key_set = SecretKeySet::random(2, &mut rng);
         let sec_key_share = sec_key_set.secret_key_share(i);
         let broadcaster = Rc::new(RefCell::new(Broadcaster::new(i)));
+        let tag = Tag::new("test-domain", j, 0);
         let vcbc = Vcbc::new(
-            id,
+            tag,
             i,
-            j,
             sec_key_set.public_keys(),
             sec_key_share,
             valid_proposal,


### PR DESCRIPTION
This PR re-works a bit of the id/tag fields in the various modules to allow for sequence numbers to be used throughout.

