### PR TITLE
Remove vote history from decision

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -137,7 +137,6 @@ impl<T: Proposition> Consensus<T> {
             let decision = Decision {
                 generation: signed_vote.vote.gen,
                 proposals,
-                faults: signed_vote.vote.faults.clone(),
             };
             self.decision = Some(decision);
             return Ok(VoteResponse::WaitingForMoreVotes);
@@ -153,7 +152,6 @@ impl<T: Proposition> Consensus<T> {
             let decision = Decision {
                 generation: signed_vote.vote.gen,
                 proposals,
-                faults: self.faults(),
             };
             self.decision = Some(decision);
             return Ok(VoteResponse::WaitingForMoreVotes);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -155,12 +155,12 @@ impl<T: Proposition> Consensus<T> {
             };
             self.decision = Some(decision);
 
-            let signed_vote = self.build_super_majority_vote(
+            let vote = self.build_super_majority_vote(
                 self.votes.values().cloned().collect(),
-                BTreeSet::from_iter(self.faults.values().cloned()),
+                self.faults.values().cloned().collect(),
                 signed_vote.vote.gen,
             )?;
-            return Ok(VoteResponse::Broadcast(signed_vote));
+            return Ok(VoteResponse::Broadcast(vote));
         }
 
         if vote_count.is_split_vote(&self.elders, self.n_elders) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -134,9 +134,8 @@ impl<T: Proposition> Consensus<T> {
                 "[{}] They terminated but we haven't yet, accepting decision",
                 self.id()
             );
-            let votes = crate::vote::simplify_votes(&self.votes.values().cloned().collect());
             let decision = Decision {
-                votes,
+                generation: signed_vote.vote.gen,
                 proposals,
                 faults: signed_vote.vote.faults.clone(),
             };
@@ -151,19 +150,13 @@ impl<T: Proposition> Consensus<T> {
                 "[{}] Detected super majority over super majorities: {proposals:?}",
                 self.id()
             );
-            let votes = crate::vote::simplify_votes(&self.votes.values().cloned().collect());
             let decision = Decision {
-                votes,
+                generation: signed_vote.vote.gen,
                 proposals,
                 faults: self.faults(),
             };
-            let vote = self.build_super_majority_vote(
-                decision.votes.clone(),
-                decision.faults.clone(),
-                signed_vote.vote.gen,
-            )?;
             self.decision = Some(decision);
-            return Ok(VoteResponse::Broadcast(vote));
+            return Ok(VoteResponse::WaitingForMoreVotes);
         }
 
         if vote_count.is_split_vote(&self.elders, self.n_elders) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -154,7 +154,13 @@ impl<T: Proposition> Consensus<T> {
                 proposals,
             };
             self.decision = Some(decision);
-            return Ok(VoteResponse::WaitingForMoreVotes);
+
+            let signed_vote = self.build_super_majority_vote(
+                self.votes.values().cloned().collect(),
+                BTreeSet::from_iter(self.faults.values().cloned()),
+                signed_vote.vote.gen,
+            )?;
+            return Ok(VoteResponse::Broadcast(signed_vote));
         }
 
         if vote_count.is_split_vote(&self.elders, self.n_elders) {

--- a/src/decision.rs
+++ b/src/decision.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use blsttc::{PublicKeySet, Signature};
+use blsttc::{PublicKey, Signature};
 use serde::{Deserialize, Serialize};
 
 use crate::{verify_sig, Generation, Proposition, Result};
@@ -12,9 +12,9 @@ pub struct Decision<T: Proposition> {
 }
 
 impl<T: Proposition> Decision<T> {
-    pub fn validate(&self, voters: &PublicKeySet) -> Result<()> {
+    pub fn validate(&self, public_key: &PublicKey) -> Result<()> {
         for (proposal, sig) in self.proposals.iter() {
-            verify_sig(proposal, sig, &voters.public_key())?;
+            verify_sig(proposal, sig, public_key)?;
         }
 
         Ok(())

--- a/src/decision.rs
+++ b/src/decision.rs
@@ -1,15 +1,14 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use blsttc::{PublicKeySet, Signature};
 use serde::{Deserialize, Serialize};
 
-use crate::{verify_sig, Error, Fault, Generation, NodeId, Proposition, Result};
+use crate::{verify_sig, Generation, Proposition, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Decision<T: Proposition> {
     pub generation: Generation,
     pub proposals: BTreeMap<T, Signature>,
-    pub faults: BTreeSet<Fault<T>>,
 }
 
 impl<T: Proposition> Decision<T> {
@@ -18,13 +17,6 @@ impl<T: Proposition> Decision<T> {
             verify_sig(proposal, sig, &voters.public_key())?;
         }
 
-        for fault in self.faults.iter() {
-            fault.validate(voters).map_err(Error::FaultIsFaulty)?;
-        }
-
         Ok(())
-    }
-    pub fn faulty_ids(&self) -> BTreeSet<NodeId> {
-        BTreeSet::from_iter(self.faults.iter().map(Fault::voter_at_fault))
     }
 }

--- a/src/decision.rs
+++ b/src/decision.rs
@@ -1,85 +1,30 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use blsttc::{PublicKeySet, Signature};
-use log::warn;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, Fault, Generation, NodeId, Proposition, Result, SignedVote, VoteCount};
+use crate::{verify_sig, Error, Fault, Generation, NodeId, Proposition, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Decision<T: Proposition> {
-    pub votes: BTreeSet<SignedVote<T>>,
+    pub generation: Generation,
     pub proposals: BTreeMap<T, Signature>,
     pub faults: BTreeSet<Fault<T>>,
 }
 
 impl<T: Proposition> Decision<T> {
     pub fn validate(&self, voters: &PublicKeySet) -> Result<()> {
-        let all_votes = self.votes_by_voter();
-        let known_faulty_voters = self.faulty_ids();
-        let expected_generation = self.generation()?;
-
-        for vote in self.votes.iter() {
-            vote.validate(voters, &Default::default())?;
-
-            if vote.vote.gen != expected_generation {
-                warn!("Not all votes in decision are from same generation");
-                return Err(Error::InvalidDecision);
-            }
-
-            if let Err(faults) =
-                vote.detect_byzantine_faults(voters, &all_votes, &Default::default())
-            {
-                let detected_faults = BTreeSet::from_iter(faults.into_keys());
-                if !detected_faults.is_subset(&known_faulty_voters) {
-                    warn!("Detected faulty voters who is not present in faults");
-                    return Err(Error::InvalidDecision);
-                }
-            }
+        for (proposal, sig) in self.proposals.iter() {
+            verify_sig(proposal, sig, &voters.public_key())?;
         }
 
         for fault in self.faults.iter() {
             fault.validate(voters).map_err(Error::FaultIsFaulty)?;
         }
 
-        let vote_count = VoteCount::count(self.votes.iter().cloned(), &self.faulty_ids());
-        if let Some(proposals) = vote_count.get_decision(voters)? {
-            if proposals != self.proposals {
-                warn!("Proposals from votes does not match decision proposals");
-                return Err(Error::InvalidDecision);
-            }
-        } else {
-            warn!("Votes in decision don't form a decision");
-            return Err(Error::InvalidDecision);
-        }
-
         Ok(())
     }
-
-    pub fn votes_by_voter(&self) -> BTreeMap<NodeId, SignedVote<T>> {
-        let mut all_votes = BTreeMap::new();
-
-        for vote in self.votes.iter().flat_map(|v| v.unpack_votes()) {
-            let existing_vote = all_votes.entry(vote.voter).or_insert_with(|| vote.clone());
-
-            if vote.supersedes(existing_vote) {
-                all_votes.insert(vote.voter, vote.clone());
-            }
-        }
-
-        all_votes
-    }
-
     pub fn faulty_ids(&self) -> BTreeSet<NodeId> {
         BTreeSet::from_iter(self.faults.iter().map(Fault::voter_at_fault))
-    }
-
-    /// Returns the generation of this decision.
-    /// Assumes that Decision::validate() has already been checked.
-    pub fn generation(&self) -> Result<Generation> {
-        match self.votes.iter().next() {
-            Some(vote) => Ok(vote.vote.gen),
-            None => Err(Error::DecisionHasNoVotes),
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod bad_crypto;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 
-use blsttc::{PublicKeySet, PublicKey, SignatureShare, Signature};
+use blsttc::{PublicKey, PublicKeySet, Signature, SignatureShare};
 use serde::Serialize;
 
 pub use crate::consensus::{Consensus, VoteResponse};
@@ -52,11 +52,7 @@ pub fn verify_sig_share<M: Serialize>(
     }
 }
 
-pub fn verify_sig<M: Serialize>(
-    msg: &M,
-    sig: &Signature,
-    public_key: &PublicKey,
-) -> Result<()> {
+pub fn verify_sig<M: Serialize>(msg: &M, sig: &Signature, public_key: &PublicKey) -> Result<()> {
     let msg_bytes = bincode::serialize(msg)?;
     if public_key.verify(sig, msg_bytes) {
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod bad_crypto;
 #[cfg(feature = "ed25519")]
 pub mod ed25519;
 
-use blsttc::{PublicKeySet, SignatureShare};
+use blsttc::{PublicKeySet, PublicKey, SignatureShare, Signature};
 use serde::Serialize;
 
 pub use crate::consensus::{Consensus, VoteResponse};
@@ -44,6 +44,19 @@ pub fn verify_sig_share<M: Serialize>(
     voters: &PublicKeySet,
 ) -> Result<()> {
     let public_key = voters.public_key_share(voter as u64);
+    let msg_bytes = bincode::serialize(msg)?;
+    if public_key.verify(sig, msg_bytes) {
+        Ok(())
+    } else {
+        Err(Error::InvalidElderSignature)
+    }
+}
+
+pub fn verify_sig<M: Serialize>(
+    msg: &M,
+    sig: &Signature,
+    public_key: &PublicKey,
+) -> Result<()> {
     let msg_bytes = bincode::serialize(msg)?;
     if public_key.verify(sig, msg_bytes) {
         Ok(())

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use log::info;
 
 use crate::consensus::{Consensus, VoteResponse};
-use crate::vote::{Ballot, Proposition, SignedVote, Vote, simplify_votes};
+use crate::vote::{simplify_votes, Ballot, Proposition, SignedVote, Vote};
 use crate::{Error, NodeId, Result};
 
 pub type UniqueSectionId = u64;
@@ -59,7 +59,9 @@ impl<T: Proposition> Handover<T> {
             )?;
             Ok(vec![vote])
         } else {
-            Ok(Vec::from_iter(simplify_votes(&self.consensus.votes.values().cloned().collect())))
+            Ok(Vec::from_iter(simplify_votes(
+                &self.consensus.votes.values().cloned().collect(),
+            )))
         }
     }
 

--- a/src/sn_handover.rs
+++ b/src/sn_handover.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use log::info;
 
 use crate::consensus::{Consensus, VoteResponse};
-use crate::vote::{Ballot, Proposition, SignedVote, Vote};
+use crate::vote::{Ballot, Proposition, SignedVote, Vote, simplify_votes};
 use crate::{Error, NodeId, Result};
 
 pub type UniqueSectionId = u64;
@@ -51,15 +51,15 @@ impl<T: Proposition> Handover<T> {
     pub fn anti_entropy(&self) -> Result<Vec<SignedVote<T>>> {
         info!("[HDVR] anti-entropy from {:?}", self.id());
 
-        if let Some(decision) = self.consensus.decision.as_ref() {
+        if let Some(_decision) = self.consensus.decision.as_ref() {
             let vote = self.consensus.build_super_majority_vote(
-                decision.votes.clone(),
-                decision.faults.clone(),
+                self.consensus.votes.values().cloned().collect(),
+                self.consensus.faults.values().cloned().collect(),
                 self.gen,
             )?;
             Ok(vec![vote])
         } else {
-            Ok(self.consensus.votes.values().cloned().collect())
+            Ok(Vec::from_iter(simplify_votes(&self.consensus.votes.values().cloned().collect())))
         }
     }
 

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -6,7 +6,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 
 use crate::consensus::{Consensus, VoteResponse};
-use crate::vote::{Ballot, Proposition, SignedVote, Vote, simplify_votes};
+use crate::vote::{simplify_votes, Ballot, Proposition, SignedVote, Vote};
 use crate::{Error, NodeId, Result};
 
 const SOFT_MAX_MEMBERS: usize = 7;
@@ -172,7 +172,9 @@ impl<T: Proposition> Membership<T> {
             .collect::<Result<Vec<_>>>()?;
 
         // include the current in-progres votes as well.
-        msgs.extend(simplify_votes(&self.consensus.votes.values().cloned().collect()));
+        msgs.extend(simplify_votes(
+            &self.consensus.votes.values().cloned().collect(),
+        ));
 
         Ok(msgs)
     }

--- a/src/sn_membership.rs
+++ b/src/sn_membership.rs
@@ -202,8 +202,8 @@ impl<T: Proposition> Membership<T> {
             );
 
             let decided_consensus = std::mem::replace(&mut self.consensus, next_consensus);
-            self.history.insert(vote_gen, decided_consensus);
-            self.gen = vote_gen
+            self.gen += 1;
+            self.history.insert(self.gen, decided_consensus);
         }
 
         Ok(vote_response)

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -28,7 +28,10 @@ pub struct Net {
 
 impl Net {
     pub fn with_procs(threshold: usize, n: usize, mut rng: &mut StdRng) -> Self {
-        assert!(3 * (threshold + 1) > 2 * n, "ASSERT: 3 * ({threshold} + 1) > 2 * {n}");
+        assert!(
+            3 * (threshold + 1) > 2 * n,
+            "ASSERT: 3 * ({threshold} + 1) > 2 * {n}"
+        );
         let elders_sk = SecretKeySet::random(threshold, &mut rng);
 
         let procs = Vec::from_iter((1..=n).map(|i| {

--- a/tests/handover_net.rs
+++ b/tests/handover_net.rs
@@ -28,6 +28,7 @@ pub struct Net {
 
 impl Net {
     pub fn with_procs(threshold: usize, n: usize, mut rng: &mut StdRng) -> Self {
+        assert!(3 * (threshold + 1) > 2 * n, "ASSERT: 3 * ({threshold} + 1) > 2 * {n}");
         let elders_sk = SecretKeySet::random(threshold, &mut rng);
 
         let procs = Vec::from_iter((1..=n).map(|i| {

--- a/tests/membership_net.rs
+++ b/tests/membership_net.rs
@@ -196,7 +196,7 @@ impl Net {
                 assert_eq!(net_d.proposals, proc_d.proposals);
             }
             (None, Some(proc_d)) => {
-                assert!(proc_d.validate(&proc.consensus.elders).is_ok());
+                assert!(proc_d.validate(&proc.consensus.elders.public_key()).is_ok());
                 self.decisions.insert(packet_gen, proc_d);
             }
             (None | Some(_), None) => (),

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -16,7 +16,7 @@ mod membership_net;
 use quickcheck::{Arbitrary, Gen, TestResult};
 use quickcheck_macros::quickcheck;
 use sn_consensus::{
-    Ballot, Error, Fault, Generation, Membership, Reconfig, Result, SignedVote, Vote,
+    Ballot, Error, Generation, Membership, Reconfig, Result, SignedVote, Vote,
 };
 
 static INIT: std::sync::Once = std::sync::Once::new();
@@ -869,7 +869,7 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
 
         // check that the decision includes the discovery that `faulty` was faulty
         assert_eq!(
-            Vec::from_iter(decision.faults.iter().map(Fault::voter_at_fault)),
+            Vec::from_iter(p.consensus.faulty_ids()),
             vec![faulty]
         );
 
@@ -932,7 +932,7 @@ fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
 
         // check that the decision includes the discovery that `faulty` was faulty
         assert_eq!(
-            Vec::from_iter(decision.faults.iter().map(Fault::voter_at_fault)),
+            Vec::from_iter(p.consensus.faulty_ids()),
             vec![faulty]
         );
 
@@ -1013,7 +1013,7 @@ fn test_membership_final_broadcast_on_decision_catches_up_stragglers() -> Result
         let consensus = p.consensus_at_gen(1).unwrap();
         let decision = consensus.decision.as_ref().unwrap();
 
-        assert_eq!(decision.faulty_ids(), BTreeSet::from_iter([1]));
+        assert_eq!(consensus.faulty_ids(), BTreeSet::from_iter([1]));
         assert_eq!(
             BTreeSet::from_iter(decision.proposals.keys()),
             BTreeSet::from_iter([&Reconfig::Join(66)])

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -584,7 +584,7 @@ fn test_membership_bft_consensus_qc1() -> Result<()> {
     let packet = Packet {
         source: 2,
         dest: 1,
-        vote: net.proc(2).unwrap().sign_vote(Vote {
+        vote: net.proc(2).sign_vote(Vote {
             gen: 1,
             ballot: Ballot::Propose(Reconfig::Join(240)),
             faults: Default::default(),
@@ -596,7 +596,7 @@ fn test_membership_bft_consensus_qc1() -> Result<()> {
         dest: 1,
         vote: SignedVote {
             voter: 2,
-            ..net.proc(6).unwrap().sign_vote(Vote {
+            ..net.proc(6).sign_vote(Vote {
                 gen: 0,
                 ballot: Ballot::Propose(Reconfig::Join(115)),
                 faults: Default::default(),
@@ -639,10 +639,10 @@ fn test_membership_bft_consensus_qc2() -> Result<()> {
     let faulty = 1;
     let honest = 2;
     // node takes honest action
-    let vote = net.proc_mut(honest).unwrap().propose(Reconfig::Join(0))?;
+    let vote = net.proc_mut(honest).propose(Reconfig::Join(0))?;
     net.broadcast(honest, vote);
 
-    let faulty_proc = net.proc(faulty).unwrap();
+    let faulty_proc = net.proc(faulty);
     let packet = Packet {
         source: faulty,
         dest: honest,
@@ -693,7 +693,6 @@ fn test_membership_bft_consensus_qc3() -> Result<()> {
     {
         let vote = net
             .proc_mut(proposer_a)
-            .unwrap()
             .propose(Reconfig::Join(11))
             .unwrap();
         net.broadcast(proposer_a, vote);
@@ -705,7 +704,6 @@ fn test_membership_bft_consensus_qc3() -> Result<()> {
             dest: proposer_b,
             vote: net
                 .proc(faulty)
-                .unwrap()
                 .sign_vote(Vote {
                     gen: 1,
                     ballot: Ballot::Propose(Reconfig::Join(22)),
@@ -719,7 +717,6 @@ fn test_membership_bft_consensus_qc3() -> Result<()> {
     {
         let vote = net
             .proc_mut(proposer_b)
-            .unwrap()
             .propose(Reconfig::Join(33))
             .unwrap();
         net.broadcast(proposer_b, vote);
@@ -768,13 +765,13 @@ fn test_membership_votes_from_faulty_nodes_dont_contribute_to_vote_counts() -> R
 
     {
         // node takes honest action
-        let proc = net.proc_mut(honest).unwrap();
+        let proc = net.proc_mut(honest);
         let vote = proc.propose(Reconfig::Join(11)).unwrap();
         net.broadcast(honest, vote);
     }
 
     {
-        let faulty_proc = net.proc(faulty).unwrap();
+        let faulty_proc = net.proc(faulty);
         let packet = Packet {
             source: faulty,
             dest: honest,
@@ -828,7 +825,7 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
     let honest = 1;
     {
         // send a randomized packet
-        let faulty_proc = net.proc(faulty).unwrap();
+        let faulty_proc = net.proc(faulty);
         let packet = Packet {
             source: faulty,
             dest: honest,
@@ -844,11 +841,7 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
     }
 
     {
-        let vote = net
-            .proc_mut(faulty)
-            .unwrap()
-            .propose(Reconfig::Join(33))
-            .unwrap();
+        let vote = net.proc_mut(faulty).propose(Reconfig::Join(33)).unwrap();
         net.broadcast(faulty, vote);
     }
 
@@ -883,7 +876,7 @@ fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
     let honest = 2;
     {
         // send a randomized packet
-        let faulty_proc = net.proc(faulty).unwrap();
+        let faulty_proc = net.proc(faulty);
         let packet = Packet {
             source: faulty,
             dest: honest,
@@ -899,11 +892,7 @@ fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
     }
 
     {
-        let vote = net
-            .proc_mut(faulty)
-            .unwrap()
-            .propose(Reconfig::Join(33))
-            .unwrap();
+        let vote = net.proc_mut(faulty).propose(Reconfig::Join(33)).unwrap();
         net.broadcast(faulty, vote);
     }
 
@@ -957,15 +946,12 @@ fn test_membership_final_broadcast_on_decision_catches_up_stragglers() -> Result
 
     {
         // node takes honest action
-        let vote = net
-            .proc_mut(honest_a)
-            .unwrap()
-            .propose(Reconfig::Join(66))?;
+        let vote = net.proc_mut(honest_a).propose(Reconfig::Join(66))?;
         net.broadcast(honest_a, vote);
     }
     {
         // send a randomized packet
-        let faulty_proc = net.proc(faulty).unwrap();
+        let faulty_proc = net.proc(faulty);
         let packet = Packet {
             source: faulty,
             dest: honest_b,
@@ -1027,7 +1013,7 @@ fn test_membership_scenario_requiring_us_to_filter_to_most_recent_votes_when_cou
         let packet = Packet {
             source: faulty,
             dest: honest_a,
-            vote: net.proc(faulty).unwrap().sign_vote(Vote {
+            vote: net.proc(faulty).sign_vote(Vote {
                 gen: 1,
                 ballot: Ballot::Propose(Reconfig::Join(11)),
                 faults: Default::default(),
@@ -1037,17 +1023,11 @@ fn test_membership_scenario_requiring_us_to_filter_to_most_recent_votes_when_cou
     }
 
     {
-        let vote = net
-            .proc_mut(honest_b)
-            .unwrap()
-            .propose(Reconfig::Join(22))?;
+        let vote = net.proc_mut(honest_b).propose(Reconfig::Join(22))?;
         net.broadcast(honest_b, vote);
     }
     {
-        let vote = net
-            .proc_mut(honest_c)
-            .unwrap()
-            .propose(Reconfig::Join(33))?;
+        let vote = net.proc_mut(honest_c).propose(Reconfig::Join(33))?;
         net.broadcast(honest_c, vote);
     }
 
@@ -1080,11 +1060,7 @@ fn test_membership_ensure_that_candidates_are_being_chosen_based_on_vote_count()
     let mut net = Net::with_procs((2 * n) / 3, n, &mut rng);
 
     {
-        let vote = net
-            .proc_mut(5)
-            .unwrap()
-            .propose(Reconfig::Join(255))
-            .unwrap();
+        let vote = net.proc_mut(5).propose(Reconfig::Join(255)).unwrap();
         net.broadcast(5, vote);
     }
 
@@ -1093,11 +1069,7 @@ fn test_membership_ensure_that_candidates_are_being_chosen_based_on_vote_count()
     }
 
     {
-        let vote = net
-            .proc_mut(4)
-            .unwrap()
-            .propose(Reconfig::Join(144))
-            .unwrap();
+        let vote = net.proc_mut(4).propose(Reconfig::Join(144)).unwrap();
         net.broadcast(4, vote);
     }
 
@@ -1143,7 +1115,7 @@ fn test_membership_ensure_we_are_validating_super_majority_proposals() -> Result
     let id_b = 4;
     {
         let reconfig = Reconfig::Join(1);
-        let vote = net.proc_mut(id_a).unwrap().propose(reconfig).unwrap();
+        let vote = net.proc_mut(id_a).propose(reconfig).unwrap();
         net.reconfigs_by_gen
             .entry(vote.vote.gen)
             .or_default()
@@ -1158,7 +1130,7 @@ fn test_membership_ensure_we_are_validating_super_majority_proposals() -> Result
 
     {
         let reconfig = Reconfig::Join(0);
-        let vote = net.proc_mut(id_b).unwrap().propose(reconfig).unwrap();
+        let vote = net.proc_mut(id_b).propose(reconfig).unwrap();
         net.reconfigs_by_gen
             .entry(vote.vote.gen)
             .or_default()
@@ -1411,6 +1383,74 @@ fn prop_validate_reconfig(
     };
 
     Ok(TestResult::passed())
+}
+
+#[test]
+fn test_honest_nodes_broadcast_decisions() -> Result<()> {
+    init();
+
+    let mut rng = rand::rngs::StdRng::from_seed([0u8; 32]);
+
+    let mut net = Net::with_procs(2, 4, &mut rng);
+
+    let faulty = 2;
+    let faulty_target = 3;
+
+    {
+        // node takes honest action
+        let source = 1;
+        let vote = net.proc_mut(source).propose(Reconfig::Join(11)).unwrap();
+        net.broadcast(source, vote);
+    }
+
+    {
+        let vote = net
+            .proc(faulty)
+            .sign_vote(Vote {
+                gen: 1,
+                ballot: Ballot::Propose(Reconfig::Join(22)),
+                faults: Default::default(),
+            })
+            .unwrap();
+
+        net.send(faulty, faulty_target, vote);
+    }
+
+    {
+        // node takes honest action
+        let source = 4;
+        let vote = net.proc_mut(source).propose(Reconfig::Join(33)).unwrap();
+        net.broadcast(source, vote);
+    }
+
+    while let Err(e) = net.drain_queued_packets() {
+        println!("Error while draining: {e:?}");
+    }
+
+    let _ = net.generate_msc("test_honest_nodes_broadcast_decisions.msc");
+
+    let honest_procs = Vec::from_iter(net.procs.iter().filter(|p| p.id() != faulty));
+
+    // BFT TERMINATION PROPERTY: all honest procs have decided ==>
+    for p in honest_procs.iter() {
+        dbg!(&p);
+        for g in 1..=p.gen {
+            assert!(p.consensus_at_gen(g).unwrap().decision.is_some())
+        }
+        assert_eq!(p.consensus.decision, None); // because it should have moved on to the next generation
+        assert_eq!(p.consensus.votes, BTreeMap::default());
+    }
+
+    // BFT AGREEMENT PROPERTY: all honest procs have decided on the same values
+    let reference_proc = &honest_procs[0];
+    for p in honest_procs.iter() {
+        assert_eq!(reference_proc.gen, p.gen);
+        for g in 0..=reference_proc.gen {
+            assert_eq!(reference_proc.members(g).unwrap(), p.members(g).unwrap())
+        }
+    }
+
+    Ok(())
 }
 
 #[quickcheck]

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -865,9 +865,6 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
         assert_eq!(p.gen, 1);
         let decision = p.consensus_at_gen(1).unwrap().decision.as_ref().unwrap();
 
-        // check that the decision includes the discovery that `faulty` was faulty
-        assert_eq!(Vec::from_iter(p.consensus.faulty_ids()), vec![faulty]);
-
         assert_eq!(
             BTreeSet::from_iter(decision.proposals.keys()),
             BTreeSet::from_iter([&Reconfig::Join(22)])
@@ -880,9 +877,8 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
 #[test]
 fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
     init();
-    let n = 5;
     let mut rng = rand::rngs::StdRng::from_seed([0u8; 32]);
-    let mut net = Net::with_procs((2 * n) / 3, n, &mut rng);
+    let mut net = Net::with_procs(3, 5, &mut rng);
     let faulty = 1;
     let honest = 2;
     {
@@ -924,9 +920,6 @@ fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
         assert_eq!(p.consensus.decision, None);
         assert_eq!(p.gen, 1);
         let decision = p.consensus_at_gen(1).unwrap().decision.as_ref().unwrap();
-
-        // check that the decision includes the discovery that `faulty` was faulty
-        assert_eq!(Vec::from_iter(p.consensus.faulty_ids()), vec![faulty]);
 
         // since all proposals were initiated by faulty voters, we end up with 0 proposals as the decision
         assert_eq!(decision.proposals, BTreeMap::new());

--- a/tests/sn_membership.rs
+++ b/tests/sn_membership.rs
@@ -15,9 +15,7 @@ mod membership_net;
 
 use quickcheck::{Arbitrary, Gen, TestResult};
 use quickcheck_macros::quickcheck;
-use sn_consensus::{
-    Ballot, Error, Generation, Membership, Reconfig, Result, SignedVote, Vote,
-};
+use sn_consensus::{Ballot, Error, Generation, Membership, Reconfig, Result, SignedVote, Vote};
 
 static INIT: std::sync::Once = std::sync::Once::new();
 
@@ -868,10 +866,7 @@ fn test_membership_faulty_node_attempts_to_trick_honest_node() -> Result<()> {
         let decision = p.consensus_at_gen(1).unwrap().decision.as_ref().unwrap();
 
         // check that the decision includes the discovery that `faulty` was faulty
-        assert_eq!(
-            Vec::from_iter(p.consensus.faulty_ids()),
-            vec![faulty]
-        );
+        assert_eq!(Vec::from_iter(p.consensus.faulty_ids()), vec![faulty]);
 
         assert_eq!(
             BTreeSet::from_iter(decision.proposals.keys()),
@@ -931,10 +926,7 @@ fn test_membership_we_can_agree_to_an_empty_set() -> Result<()> {
         let decision = p.consensus_at_gen(1).unwrap().decision.as_ref().unwrap();
 
         // check that the decision includes the discovery that `faulty` was faulty
-        assert_eq!(
-            Vec::from_iter(p.consensus.faulty_ids()),
-            vec![faulty]
-        );
+        assert_eq!(Vec::from_iter(p.consensus.faulty_ids()), vec![faulty]);
 
         // since all proposals were initiated by faulty voters, we end up with 0 proposals as the decision
         assert_eq!(decision.proposals, BTreeMap::new());


### PR DESCRIPTION
This is done to reduce the size of the decision structs and to speed up the validation time.