### PR TITLE
fix: adding clone attribute to the outgoing

### DIFF
--- a/src/mvba/bundle.rs
+++ b/src/mvba/bundle.rs
@@ -20,7 +20,7 @@ pub enum Message<P> {
 }
 
 /// Ongoing messages definition
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Outgoing<P> {
     Gossip(Bundle<P>),
     Direct(NodeId, Bundle<P>),


### PR DESCRIPTION
Adding Clone attribute to Outgoing struct. 