### PR TITLE
fix: adding validator context

### DIFF
--- a/src/mvba/mod.rs
+++ b/src/mvba/mod.rs
@@ -52,7 +52,7 @@ impl Proof {
 /// MessageValidity is same as &Q_{ID}$ ins spec: a global polynomial-time computable
 /// predicate QID known to all parties, which is determined by an external application.
 /// Each party may propose a value v together with a proof π that should satisfy QID .
-pub type MessageValidity<P> = fn(NodeId, &P) -> bool;
+pub type MessageValidity<C, P> = fn(&C, &Domain, NodeId, &P) -> bool;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct Decision<P> {

--- a/src/mvba/vcbc/proptest.rs
+++ b/src/mvba/vcbc/proptest.rs
@@ -9,7 +9,7 @@ use blsttc::SecretKeySet;
 use quickcheck_macros::quickcheck;
 use std::collections::BTreeMap;
 
-fn valid_proposal(_: NodeId, _: &char) -> bool {
+fn validate_proposal(_: &i32, _: &Domain, _: NodeId, _: &char) -> bool {
     true
 }
 
@@ -17,7 +17,7 @@ fn valid_proposal(_: NodeId, _: &char) -> bool {
 struct Net {
     domain: Domain,
     secret_key_set: SecretKeySet,
-    nodes: BTreeMap<NodeId, (Vcbc<char>, Broadcaster<char>)>,
+    nodes: BTreeMap<NodeId, (Vcbc<i32, char>, Broadcaster<char>)>,
     queue: BTreeMap<NodeId, Vec<Bundle<char>>>,
 }
 
@@ -44,7 +44,8 @@ impl Net {
                 self_id,
                 public_key_set.clone(),
                 key_share,
-                valid_proposal,
+                validate_proposal,
+                0,
             );
             (self_id, (vcbc, broadcaster))
         }));
@@ -57,7 +58,7 @@ impl Net {
         }
     }
 
-    fn node_mut(&mut self, id: NodeId) -> &mut (Vcbc<char>, Broadcaster<char>) {
+    fn node_mut(&mut self, id: NodeId) -> &mut (Vcbc<i32, char>, Broadcaster<char>) {
         self.nodes.get_mut(&id).unwrap()
     }
 

--- a/src/mvba/vcbc/test.rs
+++ b/src/mvba/vcbc/test.rs
@@ -11,17 +11,13 @@ use blsttc::{SecretKeySet, Signature, SignatureShare};
 
 use rand::{thread_rng, Rng};
 
-fn valid_proposal(_: NodeId, _: &char) -> bool {
-    true
-}
-
-fn invalid_proposal(_: NodeId, _: &char) -> bool {
-    false
+fn validate_proposal(c: &i32, _: &Domain, _: NodeId, _: &char) -> bool {
+    c == &0
 }
 
 struct TestNet {
     sec_key_set: SecretKeySet,
-    vcbc: Vcbc<char>,
+    vcbc: Vcbc<i32, char>,
     m: char,
     broadcaster: Broadcaster<char>,
 }
@@ -46,7 +42,8 @@ impl TestNet {
             i,
             sec_key_set.public_keys(),
             sec_key_share,
-            valid_proposal,
+            validate_proposal,
+            0,
         );
 
         // Creating a random proposal
@@ -142,7 +139,7 @@ fn test_invalid_message() {
     let i = TestNet::PARTY_X;
     let j = TestNet::PARTY_B;
     let mut t = TestNet::new(i, j);
-    t.vcbc.message_validity = invalid_proposal;
+    t.vcbc.validity_context = 1;
 
     let msg = t.make_send_msg(t.m);
 


### PR DESCRIPTION
Introducing `validator_context` as a parameter to message validity to verify proposal.
